### PR TITLE
Parameter munging utilities

### DIFF
--- a/src/DiffEqFlux.jl
+++ b/src/DiffEqFlux.jl
@@ -3,6 +3,7 @@ module DiffEqFlux
 using DiffEqBase, Flux, DiffResults, DiffEqSensitivity, ForwardDiff
 
 include("Flux/layers.jl")
+include("Flux/utils.jl")
 
 export diffeq_fd, diffeq_rd, diffeq_adjoint
 end

--- a/src/Flux/utils.jl
+++ b/src/Flux/utils.jl
@@ -1,0 +1,18 @@
+function destructure(m)
+  xs = []
+  mapleaves(m) do x
+    x isa TrackedArray && push!(xs, x)
+    return x
+  end
+  return vcat(vec.(xs)...)
+end
+
+function restructure(m, xs)
+  i = 0
+  mapleaves(m) do x
+    x isa TrackedArray || return x
+    x = reshape(xs[i.+(1:length(x))], size(x))
+    i += length(x)
+    return x
+  end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,1 +1,8 @@
+using DiffEqFlux, Test
+
+@testset "DiffEqFlux" begin
+
 include("layers.jl")
+include("utils.jl")
+
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,14 @@
+using Flux, Test
+using DiffEqFlux: destructure, restructure
+
+model = Chain(Dense(10, 5, relu), Dense(5, 2))
+
+p = destructure(model)
+
+m2 = restructure(model, p)
+
+@test !Tracker.isleaf(m2[1].W)
+
+x = rand(10)
+
+@test model(x) == m2(x)


### PR DESCRIPTION
Utilities for working with Flux models under the current version of the adjoint method. Only meant as a stopgap until I rework DiffEqSensitivities.jl.

```julia
julia> model = Chain(Dense(10, 5, relu), Dense(5, 2))
Chain(Dense(10, 5, NNlib.relu), Dense(5, 2))

julia> p = destructure(model)
Tracked 67-element Array{Float32,1}:
  0.35315588f0
  0.2662674f0
  0.042073943f0
  0.049423557f0
 -0.30862498f0
  0.35268134f0
  ⋮
  0.6537891f0
 -0.38841408f0
 -0.445121f0
  0.0f0
  0.0f0

julia> restructure(model, p)
Chain(Dense(10, 5, NNlib.relu), Dense(5, 2))
```