### PR TITLE
README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,8 @@ end
 # Display the ODE with the initial parameter values.
 cb()
 
-Flux.train!(loss_n_ode, params, data, opt, cb = cb)
+ps = Flux.params(dudt)
+Flux.train!(loss_n_ode, ps, data, opt, cb = cb)
 ```
 ## Use with GPUs
 


### PR DESCRIPTION
It seems that the definition of params is missing.