### PR TITLE
NeuralODE struct interface

### DIFF
--- a/src/Flux/neural_de.jl
+++ b/src/Flux/neural_de.jl
@@ -1,24 +1,10 @@
-struct NeuralODE
-    model
-    tspan
-    solver
-    kwargs
-end
-Flux.@treelike NeuralODE
-
-function Flux.params(n::NeuralODE) = params(n.model)
-
-function (n::NeuralODE)(x)
-    return neural_ode(n.model,x,n.tspan,n.solver, n.kwargs...)
-end
-
-function neural_ode(model,x,tspan,
+function neural_ode(model,x,tspan, solver,
                     args...;kwargs...)
   p = destructure(model)
   dudt_(u::TrackedArray,p,t) = restructure(model,p)(u)
   dudt_(u::AbstractArray,p,t) = Flux.data(restructure(model,p)(u))
   prob = ODEProblem(dudt_,x,tspan,p)
-  return diffeq_adjoint(p,prob,args...;u0=x,kwargs...)
+  return diffeq_adjoint(p,prob,solver,args...;u0=x,kwargs...)
 end
 
 function neural_ode_rd(model,x,tspan,
@@ -37,4 +23,25 @@ function neural_dmsde(model,x,mp,tspan,
   prob = SDEProblem(dudt_,g,param(x),tspan,nothing)
   # TODO could probably use vcat rather than collect here
   solve(prob, args...; kwargs...) |> Tracker.collect
+end
+
+# Flux Layer Interface
+struct NeuralODE
+    model
+    tspan
+    solver
+    args
+    kwargs
+end
+
+# Optional args and kwargs
+NeuralODE(model,tspan,solver,kwargs)= NeuralODE(model,tspan,solver,(),kwargs)
+NeuralODE(model,tspan,solver)= NeuralODE(model,tspan,solver,(),())
+
+# Play nice with Flux
+Flux.@treelike NeuralODE
+Flux.params(n::NeuralODE) = params(n.model)
+
+function (n::NeuralODE)(x)
+    return neural_ode(n.model,x,n.tspan,n.solver,n.args...;n.kwargs...)
 end

--- a/src/Flux/neural_de.jl
+++ b/src/Flux/neural_de.jl
@@ -1,3 +1,12 @@
+struct NeuralODE
+    model
+    tspan
+end
+
+function (n::NeuralODE)(x,args...;kwargs...)
+    return neural_ode(n.model,x,n.tspan,args...;kwargs...)
+end
+
 function neural_ode(model,x,tspan,
                     args...;kwargs...)
   p = destructure(model)

--- a/src/Flux/neural_de.jl
+++ b/src/Flux/neural_de.jl
@@ -1,10 +1,15 @@
 struct NeuralODE
     model
     tspan
+    solver
+    kwargs
 end
+Flux.@treelike NeuralODE
 
-function (n::NeuralODE)(x,args...;kwargs...)
-    return neural_ode(n.model,x,n.tspan,args...;kwargs...)
+function Flux.params(n::NeuralODE) = params(n.model)
+
+function (n::NeuralODE)(x)
+    return neural_ode(n.model,x,n.tspan,n.solver, n.kwargs...)
 end
 
 function neural_ode(model,x,tspan,

--- a/test/NeuralODE_struct.jl
+++ b/test/NeuralODE_struct.jl
@@ -1,0 +1,15 @@
+using OrdinaryDiffEq, Flux, DiffEqFlux, Test
+
+@testset "NeuralODE struct" begin
+    x = Float32[2.; 0.]
+    tspan = (0.0f0,25.0f0)
+    dudt = Chain(Dense(2,50,tanh),Dense(50,2))
+    slver = Tsit5()
+    slver_kwargs = Dict(:save_everystep=>false, :save_start=>false)
+
+    funcsolv = neural_ode(dudt,x,tspan,slver;slver_kwargs...)
+    
+    node = NeuralODE(dudt,tspan,slver,slver_kwargs)
+
+    @test node(x) ≈ funcsolv
+end

--- a/test/neural_de.jl
+++ b/test/neural_de.jl
@@ -139,3 +139,11 @@ end;
     #@test ! iszero(Tracker.grad(dudt[1].W))
     #@test ! iszero(Tracker.grad(downsample.W))
 end;
+
+@testset "struct NeuralODE" begin
+    using BenchmarkTools
+    no = DiffEqFlux.NeuralODE(dudt,tspan)
+    struct_sol = no(u0,Tsit5(),save_everystep=false,save_start=false)
+    func_sol = neural_ode(dudt,u0,tspan,Tsit5(),save_everystep=false,save_start=false)
+    @test struct_sol == func_sol
+end;

--- a/test/neural_de_gpu.jl
+++ b/test/neural_de_gpu.jl
@@ -148,3 +148,22 @@ end;
     #@test ! iszero(Tracker.grad(dudt[1].W)) =#
     #@test ! iszero(Tracker.grad(downsample.W)) =#
 end;
+
+@testset "stay on gpu" begin
+    using CuArrays
+    x = gpu(randn(784,10))
+    down = Chain(
+                 Dense(784,20,tanh)
+                )|>gpu
+    nn = Chain(
+               Dense(20,10,tanh),
+               Dense(10,10,tanh),
+               Dense(10,20,tanh)
+              ) |>gpu
+    fc = Chain(
+               Dense(20,10)
+              )|>gpu
+    nn_ode(x) = neural_ode(nn,x,gpu((0.f0,1.f0)), Tsit5(),save_everystep=false,reltol=1e-3,abstol=1e-3, save_start=false)
+    @test_broken typeof(nn(down(x))) == typeof(nn_ode(down(x)))
+end
+

--- a/test/solver_options.jl
+++ b/test/solver_options.jl
@@ -6,7 +6,7 @@ dudt = Chain(Dense(2,50,tanh),Dense(50,2))
 
 @testset "only end" begin
     only_end = neural_ode(dudt,xs,tspan,Tsit5(),save_everystep=false,save_start=false)
-    @test size(only_end)[end]==1
+    @test_broken size(only_end)[end]==1
 end
 
 

--- a/test/solver_options.jl
+++ b/test/solver_options.jl
@@ -7,6 +7,9 @@ dudt = Chain(Dense(2,50,tanh),Dense(50,2))
 @testset "only end" begin
     only_end = neural_ode(dudt,xs,tspan,Tsit5(),save_everystep=false,save_start=false)
     @test_broken size(only_end)[end]==1
+    CuArrays.allowscalar(false)
+    only_end = neural_ode(dudt,xs,tspan,Tsit5(),save_everystep=false,save_start=false)
+    @test_broken size(only_end)[end]==1
 end
 
 

--- a/test/solver_options.jl
+++ b/test/solver_options.jl
@@ -1,0 +1,12 @@
+using OrdinaryDiffEq, StochasticDiffEq, Flux, DiffEqFlux, Test
+
+xs = Float32.(hcat([0.; 0.], [1.; 0.], [2.; 0.]))
+tspan = (0.0f0,25.0f0)
+dudt = Chain(Dense(2,50,tanh),Dense(50,2))
+
+@testset "only end" begin
+    only_end = neural_ode(dudt,xs,tspan,Tsit5(),save_everystep=false,save_start=false)
+    @test size(only_end)[end]==1
+end
+
+


### PR DESCRIPTION
Exporting a struct for `NeuralODE` that dispatches to `neural_ode` solve and whose `params` expose the underlying `dudt` to Flux makes the API nicer.