### PR TITLE
[WIP] Refactoring destructure

### DIFF
--- a/src/Flux/layers.jl
+++ b/src/Flux/layers.jl
@@ -119,6 +119,7 @@ ZygoteRules.@adjoint function _diffeq_adjoint(p,u0,prob,args...;backsolve=true,
                     sensealg=sensealg,
                     kwargs_adj...)
 
-    (reshape(dp,size(p)), reshape(du0,size(u0)), ntuple(_->nothing, 1+length(args))...)
+    rs = p isa Params ? restructure(tuple(size.(p)...), dp) : reshape(rs, length(p))
+    (rs, reshape(du0,size(u0)), ntuple(_->nothing, 1+length(args))...)
   end
 end

--- a/src/Flux/neural_de.jl
+++ b/src/Flux/neural_de.jl
@@ -21,11 +21,8 @@ kwargs key word arguments passed to ODESolve; accepts an additional key
     passes a separate callback to the adjoint solver.
 
 """
-function neural_ode(model,x,tspan,args...;kwargs...)
-  p = destructure(model)
-  _model = restructure(model,p)
-  dudt_(u::TrackedArray,p,t) = _model(u)
-  dudt_(u::AbstractArray,p,t) = Tracker.data(_model(u))
+function neural_ode(model,x,tspan,p=Flux.params(x,model),args...;kwargs...)
+  dudt_(u::AbstractArray,p,t) = model(u)
   prob = ODEProblem{false}(dudt_,x,tspan,p)
   return diffeq_adjoint(p,prob,args...;u0=x,kwargs...)
 end

--- a/src/Flux/utils.jl
+++ b/src/Flux/utils.jl
@@ -1,25 +1,19 @@
-using Flux.Zygote
-
-function params_(m)
-  i = 0
-  Flux.fmap(m) do x
-    x isa AbstractArray && (i += 1)
+function destructure(m)
+  xs = []
+  Flux.mapleaves(m) do x
+    x isa AbstractArray && push!(xs, x)
     return x
   end
-  xs = Zygote.Buffer(Vector(undef, i))
-  i = 1
-  Flux.fmap(m) do x
-    if x isa AbstractArray
-      xs[i] = x
-      i += 1
-    end
-    x
-  end
-  copy(xs)
+  return vcat(vec.(xs)...)
 end
 
-function destructure(m)
-  vcat(vec.(params_(m))...)
+ZygoteRules.@adjoint function destructure(m)
+  xs = []
+  Flux.mapleaves(m) do x
+    x isa AbstractArray && push!(xs, x)
+    return x
+  end
+  vcat(vec.(xs)...),ybar->(nothing,)
 end
 
 function restructure(m, xs)
@@ -30,4 +24,15 @@ function restructure(m, xs)
     i += length(x)
     return x
   end
+end
+
+function restructure(sz::Tuple, xs)
+  t = []
+  i = 0
+  for s in sz
+    y = reshape(xs[i.+(1:prod(s))], s)
+    push!(t,y)
+    i += length(y)
+  end
+  t
 end

--- a/test/neural_de.jl
+++ b/test/neural_de.jl
@@ -3,7 +3,7 @@ using OrdinaryDiffEq, StochasticDiffEq, Flux, DiffEqFlux, Zygote, Test
 x = Float32[2.; 0.]
 tspan = (0.0f0,25.0f0)
 dudt = Chain(Dense(2,50,tanh),Dense(50,2))
-p = Zygote.Params([x,dudt])
+p = Flux.params(x,dudt)
 neural_ode(dudt,x,tspan,Tsit5(),save_everystep=false,save_start=false)
 neural_ode(dudt,x,tspan,Tsit5(),saveat=0.1)
 neural_ode_rd(dudt,x,tspan,Tsit5(),saveat=0.1)
@@ -15,26 +15,26 @@ neural_ode_rd(dudt,x,tspan,Tsit5(),saveat=0.1)
 @testset "adjoint mode" begin
     grads = Zygote.gradient(()->sum(neural_ode(dudt,x,tspan,Tsit5(),save_everystep=false,save_start=false)),p)
     @test ! iszero(grads[x])
-    @test_broken ! iszero(grads[dudt[1]])
+    @test_broken ! iszero(grads[dudt[1].W])
     grads = Zygote.gradient(()->sum(neural_ode(dudt,x,tspan,Tsit5(),saveat=0.0:0.1:10.0)),p)
     @test ! iszero(grads[x])
-    @test_broken ! iszero(grads[dudt[1]])
+    @test_broken ! iszero(grads[dudt[1].W])
     grads = Zygote.gradient(()->sum(neural_ode(dudt,x,tspan,Tsit5(),saveat=0.1)),p)
     @test ! iszero(grads[x])
-    @test_broken ! iszero(grads[dudt[1]])
+    @test_broken ! iszero(grads[dudt[1].W])
 end
 
 # RD
 @testset "reverse mode" begin
     grads = Zygote.gradient(()->sum(neural_ode_rd(dudt,x,tspan,Tsit5(),save_everystep=false,save_start=false)),p)
     @test ! iszero(grads[x])
-    @test_broken ! iszero(grads[dudt[1]])
+    @test_broken ! iszero(grads[dudt[1].W])
     grads = Zygote.gradient(()->sum(neural_ode_rd(dudt,x,tspan,Tsit5(),saveat=0.0:0.1:10.0)),p)
     @test ! iszero(grads[x])
-    @test_broken ! iszero(grads[dudt[1]])
+    @test_broken ! iszero(grads[dudt[1].W])
     grads = Zygote.gradient(()->sum(neural_ode_rd(dudt,x,tspan,Tsit5(),saveat=0.1)),p)
     @test ! iszero(grads[x])
-    @test_broken ! iszero(grads[dudt[1]])
+    @test_broken ! iszero(grads[dudt[1].W])
 end
 
 mp = Float32[0.1,0.1]
@@ -42,7 +42,7 @@ neural_dmsde(dudt,x,mp,(0.0f0,2.0f0),SOSRI(),saveat=0.1)
 @test ! iszero(Zygote.gradient(x->sum(neural_dmsde(dudt,x,mp,(0.0f0,2.0f0),SOSRI(),saveat=0.0:0.1:2.0)),x)[1])
 grads = Zygote.gradient(()->sum(neural_dmsde(dudt,x,mp,(0.0f0,2.0f0),SOSRI(),saveat=0.0:0.1:2.0)),p)
 @test ! iszero(grads[x])
-@test_broken ! iszero(grads[dudt[1]])
+@test_broken ! iszero(grads[dudt[1].W])
 
 # Batch
 xs = Float32.(hcat([0.; 0.], [1.; 0.], [2.; 0.]))


### PR DESCRIPTION
Needs a fix on Zygote to get accumulation over `Params` objects.

Ref #96 

This replaces the `destructure` implementation with one that uses `Zygote.Buffer` to get around array mutation. It currently adds the Buffer to the list of params, but that can be ignored.

The values of the grads shouldn't be zero though, so will need to fix that.

cc @ChrisRackauckas