### PR TITLE
don't default to backsolve

### DIFF
--- a/src/Flux/layers.jl
+++ b/src/Flux/layers.jl
@@ -57,9 +57,8 @@ end
 diffeq_adjoint(p::TrackedArray,prob,args...;u0=prob.u0,kwargs...) =
   Tracker.track(diffeq_adjoint, p, u0, prob, args...; kwargs...)
 
-@grad function diffeq_adjoint(p,u0,prob,args...;backsolve=true,
+@grad function diffeq_adjoint(p,u0,prob,args...;
                               save_start=true,save_end=true,
-                              sensealg=SensitivityAlg(quad=false,backsolve=backsolve),
                               kwargs...)
 
   T = gpu_or_cpu(u0)
@@ -99,7 +98,6 @@ diffeq_adjoint(p::TrackedArray,prob,args...;u0=prob.u0,kwargs...) =
 
     ts = sol.t[sol_idxs]
     du0, dp = adjoint_sensitivities_u0(sol,args...,df,ts;
-                    sensealg=sensealg,
                     kwargs_adj...)
 
     (reshape(dp,size(p)), reshape(du0,size(u0)), ntuple(_->nothing, 1+length(args))...)


### PR DESCRIPTION
Our tests have shown that the backsolve method from https://papers.nips.cc/paper/7892-neural-ordinary-differential-equations is practically never a good idea. For standard applications, there is a high chance that backsolve is numerically unstable, and that has bitten us a few times recently. Even when it isn't unstable, the incorrect gradients increase the number of iterations required to converge and cause weird jumps in ADAM. Specifically for neural ODE applications in machine learning, the state space is so small in comparison to the parameter space that storing the continuous solution is only a tiny fraction of the total memory while at the same time reducing the number of neural network evaluations required (and the number of epochs).

So in total, the default to backsolve was a misguided idea towards "O(1) memory", which in reality O(1) can come from checkpointing and other stuff more naturally, so we shouldn't make our defaults do this method.