### PR TITLE
implement fast versions of Flux

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,9 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
+UnsafeArrays = "c4a57d5a-5b31-53a6-b365-19f8c011fbd6"
 ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]

--- a/README.md
+++ b/README.md
@@ -588,7 +588,7 @@ Now we build a neural SDE. For simplicity we will use the `NeuralDSDE`
 neural SDE with diagonal noise layer function:
 
 ```julia
-drift_dudt = FastChain(x -> x.^3,
+drift_dudt = FastChain((x,p) -> x.^3,
              FastDense(2,50,tanh),
              FastDense(50,2))
 diffusion_dudt = FastChain(FastDense(2,2))

--- a/src/DiffEqFlux.jl
+++ b/src/DiffEqFlux.jl
@@ -1,7 +1,8 @@
 module DiffEqFlux
 
 using DiffEqBase, Tracker, DiffResults, DiffEqSensitivity, ForwardDiff,
-      Flux, Requires, Adapt, LinearAlgebra, RecursiveArrayTools, Juno, Optim
+      Flux, Requires, Adapt, LinearAlgebra, RecursiveArrayTools, Juno, Optim,
+      StaticArrays, UnsafeArrays
 
 import ZygoteRules
 
@@ -54,5 +55,5 @@ export diffeq_fd, diffeq_rd, diffeq_adjoint
 export NeuralODE, NeuralDSDE, NeuralSDE, NeuralCDDE
 export neural_ode, neural_ode_rd
 export neural_dmsde
-export FastDense, FastChain
+export FastDense, StaticDense, FastChain
 end

--- a/src/DiffEqFlux.jl
+++ b/src/DiffEqFlux.jl
@@ -47,10 +47,12 @@ end
 Flux.Zygote.grad_mut(d::IdDict) = IdDict()
 
 include("train.jl")
+include("fast_layers.jl")
 include("neural_de.jl")
 
 export diffeq_fd, diffeq_rd, diffeq_adjoint
 export NeuralODE, NeuralDSDE, NeuralSDE, NeuralCDDE
 export neural_ode, neural_ode_rd
 export neural_dmsde
+export FastDense, FastChain
 end

--- a/src/DiffEqFlux.jl
+++ b/src/DiffEqFlux.jl
@@ -55,5 +55,5 @@ export diffeq_fd, diffeq_rd, diffeq_adjoint
 export NeuralODE, NeuralDSDE, NeuralSDE, NeuralCDDE
 export neural_ode, neural_ode_rd
 export neural_dmsde
-export FastDense, StaticDense, FastChain
+export FastDense, StaticDense, FastChain, initial_params
 end

--- a/src/fast_layers.jl
+++ b/src/fast_layers.jl
@@ -26,15 +26,25 @@ struct FastDense{F} <: Function
     new{typeof(σ)}(out,in,σ),vcat(vec(initW(out, in)),initb(out))
   end
 end
+# (f::FastDense)(x,p) = f.σ.(reshape(uview(p,1:(f.out*f.in)),f.out,f.in)*x .+ uview(p,(f.out*f.in+1):lastindex(p)))
 (f::FastDense)(x,p) = f.σ.(reshape(p[1:(f.out*f.in)],f.out,f.in)*x .+ p[(f.out*f.in+1):end])
 paramlength(f::FastDense) = f.out*(f.in + 1)
 
 struct StaticDense{out,in,F} <: Function
   σ::F
-  function FastDense(in::Integer, out::Integer, σ = identity;
+  function StaticDense(in::Integer, out::Integer, σ = identity;
                  initW = Flux.glorot_uniform, initb = zeros)
     new{out,in,typeof(σ)}(σ),vcat(vec(initW(out, in)),initb(out))
   end
 end
-(f::StaticDense{out,in})(x,p) where {out,in} = SMatrix*x + SVector{out}(p[(f.out*f.in+1):end])
+(f::StaticDense{out,in})(x,p) where {out,in} = f.σ.(SMatrix{out,in}(uview(p,1:(out*in)))*x .+ SVector{out}(uview(p,(out*in+1):lastindex(p))))
+ZygoteRules.@adjoint function (f::StaticDense{out,in})(x,p) where {out,in}
+  W = SMatrix{out,in}(uview(p,1:(out*in)))
+  b = SVector{out}(uview(p,(out*in+1):lastindex(p)))
+  res = f.σ.(W*x .+ b)
+  function StaticDense_adjoint(ȳ)
+    W'*ȳ,vcat(vec(ȳ*res'),ȳ)
+  end
+  res,StaticDense_adjoint
+end
 paramlength(f::StaticDense{out,in}) where {out,in} = out*(in + 1)

--- a/src/fast_layers.jl
+++ b/src/fast_layers.jl
@@ -1,0 +1,40 @@
+paramlength(f) = 0
+
+struct FastChain{T<:Tuple}
+  layers::T
+  function FastChain(xs...)
+    layers = getfunc.(xs)
+    ps = vcat(getparams.(xs)...)
+    new{typeof(layers)}(layers),ps
+  end
+end
+getfunc(x) = x
+getfunc(x::Tuple) = first(x)
+getparams(x) = Float32[]
+getparams(x::Tuple) = last(x)
+
+applychain(::Tuple{}, x, p) = x
+applychain(fs::Tuple, x, p) = applychain(Base.tail(fs), first(fs)(x,p[1:paramlength(first(fs))]), p[(paramlength(first(fs))+1):end])
+(c::FastChain)(x,p) = applychain(c.layers, x, p)
+
+struct FastDense{F} <: Function
+  out::Int
+  in::Int
+  σ::F
+  function FastDense(in::Integer, out::Integer, σ = identity;
+                 initW = Flux.glorot_uniform, initb = zeros)
+    new{typeof(σ)}(out,in,σ),vcat(vec(initW(out, in)),initb(out))
+  end
+end
+(f::FastDense)(x,p) = f.σ.(reshape(p[1:(f.out*f.in)],f.out,f.in)*x .+ p[(f.out*f.in+1):end])
+paramlength(f::FastDense) = f.out*(f.in + 1)
+
+struct StaticDense{out,in,F} <: Function
+  σ::F
+  function FastDense(in::Integer, out::Integer, σ = identity;
+                 initW = Flux.glorot_uniform, initb = zeros)
+    new{out,in,typeof(σ)}(σ),vcat(vec(initW(out, in)),initb(out))
+  end
+end
+(f::StaticDense{out,in})(x,p) where {out,in} = SMatrix*x + SVector{out}(p[(f.out*f.in+1):end])
+paramlength(f::StaticDense{out,in}) where {out,in} = out*(in + 1)

--- a/src/fast_layers.jl
+++ b/src/fast_layers.jl
@@ -1,11 +1,12 @@
 paramlength(f) = 0
+initial_params(f) = Float32[]
+initial_params(f::Chain) = Flux.destructure(f)[1]
 
 struct FastChain{T<:Tuple}
   layers::T
   function FastChain(xs...)
     layers = getfunc.(xs)
-    ps = vcat(getparams.(xs)...)
-    new{typeof(layers)}(layers),ps
+    new{typeof(layers)}(layers)
   end
 end
 getfunc(x) = x
@@ -16,25 +17,31 @@ getparams(x::Tuple) = last(x)
 applychain(::Tuple{}, x, p) = x
 applychain(fs::Tuple, x, p) = applychain(Base.tail(fs), first(fs)(x,p[1:paramlength(first(fs))]), p[(paramlength(first(fs))+1):end])
 (c::FastChain)(x,p) = applychain(c.layers, x, p)
+initial_params(c::FastChain) = vcat(initial_params.(c.layers)...)
 
-struct FastDense{F} <: Function
+struct FastDense{F,F2} <: Function
   out::Int
   in::Int
   σ::F
+  initial_params::F2
   function FastDense(in::Integer, out::Integer, σ = identity;
                  initW = Flux.glorot_uniform, initb = zeros)
-    new{typeof(σ)}(out,in,σ),vcat(vec(initW(out, in)),initb(out))
+    initial_params() = vcat(vec(initW(out, in)),initb(out))
+    new{typeof(σ),typeof(initial_params)}(out,in,σ,initial_params)
   end
 end
 # (f::FastDense)(x,p) = f.σ.(reshape(uview(p,1:(f.out*f.in)),f.out,f.in)*x .+ uview(p,(f.out*f.in+1):lastindex(p)))
 (f::FastDense)(x,p) = f.σ.(reshape(p[1:(f.out*f.in)],f.out,f.in)*x .+ p[(f.out*f.in+1):end])
 paramlength(f::FastDense) = f.out*(f.in + 1)
+initial_params(f::FastDense) = f.initial_params()
 
-struct StaticDense{out,in,F} <: Function
+struct StaticDense{out,in,F,F2} <: Function
   σ::F
+  initial_params::F2
   function StaticDense(in::Integer, out::Integer, σ = identity;
                  initW = Flux.glorot_uniform, initb = zeros)
-    new{out,in,typeof(σ)}(σ),vcat(vec(initW(out, in)),initb(out))
+    initial_params() = vcat(vec(initW(out, in)),initb(out))
+    new{out,in,typeof(σ),typeof(initial_params)}(σ,initial_params)
   end
 end
 (f::StaticDense{out,in})(x,p) where {out,in} = f.σ.(SMatrix{out,in}(uview(p,1:(out*in)))*x .+ SVector{out}(uview(p,(out*in+1):lastindex(p))))
@@ -48,3 +55,4 @@ ZygoteRules.@adjoint function (f::StaticDense{out,in})(x,p) where {out,in}
   res,StaticDense_adjoint
 end
 paramlength(f::StaticDense{out,in}) where {out,in} = out*(in + 1)
+initial_params(f::StaticDense) = f.initial_params()

--- a/src/fast_layers.jl
+++ b/src/fast_layers.jl
@@ -25,7 +25,7 @@ struct FastDense{F,F2} <: Function
   σ::F
   initial_params::F2
   function FastDense(in::Integer, out::Integer, σ = identity;
-                 initW = Flux.glorot_uniform, initb = zeros)
+                 initW = Flux.glorot_uniform, initb = Flux.zeros)
     initial_params() = vcat(vec(initW(out, in)),initb(out))
     new{typeof(σ),typeof(initial_params)}(out,in,σ,initial_params)
   end
@@ -39,7 +39,7 @@ struct StaticDense{out,in,F,F2} <: Function
   σ::F
   initial_params::F2
   function StaticDense(in::Integer, out::Integer, σ = identity;
-                 initW = Flux.glorot_uniform, initb = zeros)
+                 initW = Flux.glorot_uniform, initb = Flux.zeros)
     initial_params() = vcat(vec(initW(out, in)),initb(out))
     new{out,in,typeof(σ),typeof(initial_params)}(σ,initial_params)
   end

--- a/src/neural_de.jl
+++ b/src/neural_de.jl
@@ -52,7 +52,8 @@ struct NeuralODE{M,P,RE,T,S,A,K}
             model,p,re,tspan,solver,args,kwargs)
     end
 
-    function NeuralODE(model::FastChain,p,tspan,solver=nothing,args...;kwargs...)
+    function NeuralODE(model::FastChain,tspan,solver=nothing,args...;kwargs...)
+        p = initial_params(model)
         re = nothing
         new{typeof(model),typeof(p),typeof(re),
             typeof(tspan),typeof(solver),typeof(args),typeof(kwargs)}(

--- a/test/fast_layers.jl
+++ b/test/fast_layers.jl
@@ -1,14 +1,17 @@
 using Flux, DiffEqFlux
 
-f,p = FastDense(2,25,tanh)
-f(ones(2),p)
+f = FastDense(2,25,tanh)
+f(ones(2),initial_params(f))
 
-f1,p1 = FastDense(2,25,tanh)
-f2,p2 = FastDense(25,2,tanh)
+f1 = FastDense(2,25,tanh)
+f2 = FastDense(25,2,tanh)
+p1 = initial_params(f1)
+p2 = initial_params(f2)
 FastChain(f1,f2)[1](ones(2),[p1;p2]) == f2(f1(ones(2),p1),p2)
 
-f,p = FastChain(FastDense(2,25,tanh),FastDense(25,2,tanh))
+f = FastChain(FastDense(2,25,tanh),FastDense(25,2,tanh))
+p = initial_params(f)
 f(ones(2),p) == f2(f1(ones(2),p[1:length(p1)]),p[length(p1)+1:end])
 
-f,p = StaticDense(2,25,tanh)
-f(ones(2),p)
+f = StaticDense(2,25,tanh)
+f(ones(2),initial_params(f))

--- a/test/fast_layers.jl
+++ b/test/fast_layers.jl
@@ -1,7 +1,6 @@
 using Flux, DiffEqFlux
 
 f,p = FastDense(2,25,tanh)
-length(f)
 f(ones(2),p)
 
 f1,p1 = FastDense(2,25,tanh)
@@ -10,3 +9,6 @@ FastChain(f1,f2)[1](ones(2),[p1;p2]) == f2(f1(ones(2),p1),p2)
 
 f,p = FastChain(FastDense(2,25,tanh),FastDense(25,2,tanh))
 f(ones(2),p) == f2(f1(ones(2),p[1:length(p1)]),p[length(p1)+1:end])
+
+f,p = StaticDense(2,25,tanh)
+f(ones(2),p)

--- a/test/fast_layers.jl
+++ b/test/fast_layers.jl
@@ -1,0 +1,12 @@
+using Flux, DiffEqFlux
+
+f,p = FastDense(2,25,tanh)
+length(f)
+f(ones(2),p)
+
+f1,p1 = FastDense(2,25,tanh)
+f2,p2 = FastDense(25,2,tanh)
+FastChain(f1,f2)[1](ones(2),[p1;p2]) == f2(f1(ones(2),p1),p2)
+
+f,p = FastChain(FastDense(2,25,tanh),FastDense(25,2,tanh))
+f(ones(2),p) == f2(f1(ones(2),p[1:length(p1)]),p[length(p1)+1:end])

--- a/test/fast_layers.jl
+++ b/test/fast_layers.jl
@@ -1,17 +1,18 @@
-using Flux, DiffEqFlux
+using Flux, DiffEqFlux, Test
 
-f = FastDense(2,25,tanh)
-f(ones(2),initial_params(f))
+fd = FastDense(2,25,tanh)
+pd = initial_params(fd)
+fd(ones(2),pd)
 
 f1 = FastDense(2,25,tanh)
 f2 = FastDense(25,2,tanh)
 p1 = initial_params(f1)
 p2 = initial_params(f2)
-FastChain(f1,f2)[1](ones(2),[p1;p2]) == f2(f1(ones(2),p1),p2)
+@test FastChain(f1,f2)(ones(2),[p1;p2]) == f2(f1(ones(2),p1),p2)
 
 f = FastChain(FastDense(2,25,tanh),FastDense(25,2,tanh))
 p = initial_params(f)
-f(ones(2),p) == f2(f1(ones(2),p[1:length(p1)]),p[length(p1)+1:end])
+@test f(ones(2),p) == f2(f1(ones(2),p[1:length(p1)]),p[length(p1)+1:end])
 
-f = StaticDense(2,25,tanh)
-f(ones(2),initial_params(f))
+fs = StaticDense(2,25,tanh)
+@test fs(ones(2),pd) ≈ fd(ones(2),pd)

--- a/test/fast_neural_ode.jl
+++ b/test/fast_neural_ode.jl
@@ -12,10 +12,10 @@ t = range(tspan[1],tspan[2],length=datasize)
 prob = ODEProblem(trueODEfunc,u0,tspan)
 ode_data = Array(solve(prob,Tsit5(),saveat=t))
 
-fastdudt2,p = FastChain((x,p) -> x.^3,
+fastdudt2 = FastChain((x,p) -> x.^3,
              FastDense(2,50,tanh),
              FastDense(50,2))
-fast_n_ode = NeuralODE(fastdudt2,p,tspan,Tsit5(),saveat=t)
+fast_n_ode = NeuralODE(fastdudt2,tspan,Tsit5(),saveat=t)
 
 function fast_predict_n_ode(p)
   fast_n_ode(u0,p)
@@ -27,10 +27,10 @@ function fast_loss_n_ode(p)
     loss,pred
 end
 
-staticdudt2,p2 = FastChain((x,p) -> x.^3,
-                         StaticDense(2,50,tanh),
-                         StaticDense(50,2))
-static_n_ode = NeuralODE(staticdudt2,p,tspan,Tsit5(),saveat=t)
+staticdudt2 = FastChain((x,p) -> x.^3,
+                        StaticDense(2,50,tanh),
+                        StaticDense(50,2))
+static_n_ode = NeuralODE(staticdudt2,tspan,Tsit5(),saveat=t)
 
 function static_predict_n_ode(p)
   static_n_ode(u0,p)
@@ -57,6 +57,7 @@ function loss_n_ode(p)
     loss,pred
 end
 
+p = initial_params(fastdudt2)
 _p,re = Flux.destructure(dudt2)
 @test fastdudt2(ones(2),_p) ≈ dudt2(ones(2))
 @test staticdudt2(ones(2),_p) ≈ dudt2(ones(2))

--- a/test/fast_neural_ode.jl
+++ b/test/fast_neural_ode.jl
@@ -1,0 +1,48 @@
+using DiffEqFlux, OrdinaryDiffEq, Optim, Flux, Zygote, Test
+
+u0 = Float32[2.; 0.]
+datasize = 30
+tspan = (0.0f0,1.5f0)
+
+function trueODEfunc(du,u,p,t)
+    true_A = [-0.1 2.0; -2.0 -0.1]
+    du .= ((u.^3)'true_A)'
+end
+t = range(tspan[1],tspan[2],length=datasize)
+prob = ODEProblem(trueODEfunc,u0,tspan)
+ode_data = Array(solve(prob,Tsit5(),saveat=t))
+
+fastdudt2,p = FastChain((x,p) -> x.^3,
+             FastDense(2,50,tanh),
+             FastDense(50,2))
+fast_n_ode = NeuralODE(fastdudt2,p,tspan,Tsit5(),saveat=t)
+
+function fast_predict_n_ode(p)
+  fast_n_ode(u0,p)
+end
+
+function fast_loss_n_ode(p)
+    pred = fast_predict_n_ode(p)
+    loss = sum(abs2,ode_data .- pred)
+    loss,pred
+end
+
+dudt2 = Chain((x) -> x.^3,
+             Dense(2,50,tanh),
+             Dense(50,2))
+n_ode = NeuralODE(dudt2,tspan,Tsit5(),saveat=t)
+
+function predict_n_ode(p)
+  n_ode(u0,p)
+end
+
+function loss_n_ode(p)
+    pred = predict_n_ode(p)
+    loss = sum(abs2,ode_data .- pred)
+    loss,pred
+end
+
+_p,re = Flux.destructure(dudt2)
+@test fastdudt2(ones(2),_p) ≈ dudt2(ones(2))
+@test fast_loss_n_ode(p)[1] ≈ loss_n_ode(p)[1]
+@test Zygote.gradient((p)->fast_loss_n_ode(p)[1], p)[1] ≈ Zygote.gradient((p)->loss_n_ode(p)[1], p)[1]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ const is_TRAVIS = haskey(ENV,"TRAVIS")
 @time begin
 if GROUP == "All"
     @safetestset "Layers Tests" begin include("layers.jl") end
+    @safetestset "Fast Layers" begin include("fast_layers.jl") end
     @safetestset "Layers SciML Tests" begin include("layers_sciml.jl") end
     @safetestset "Layers SDE" begin include("layers_sde.jl") end
     @safetestset "Layers DDE" begin include("layers_dde.jl") end
@@ -14,6 +15,7 @@ if GROUP == "All"
     @safetestset "odenet" begin include("odenet.jl") end
     @safetestset "GDP Regression Tests" begin include("gdp_regression_test.jl") end
     @safetestset "Neural DE Tests" begin include("neural_de.jl") end
+    @safetestset "Fast Neural ODE Tests" begin include("fast_neural_ode.jl") end
     @safetestset "Partial Neural Tests" begin include("partial_neural.jl") end
 end
 end


### PR DESCRIPTION
```julia
using DiffEqFlux, OrdinaryDiffEq, Optim, Flux, Zygote, Test

u0 = Float32[2.; 0.]
datasize = 30
tspan = (0.0f0,1.5f0)

function trueODEfunc(du,u,p,t)
    true_A = [-0.1 2.0; -2.0 -0.1]
    du .= ((u.^3)'true_A)'
end
t = range(tspan[1],tspan[2],length=datasize)
prob = ODEProblem(trueODEfunc,u0,tspan)
ode_data = Array(solve(prob,Tsit5(),saveat=t))

fastdudt2,p = FastChain((x,p) -> x.^3,
             FastDense(2,50,tanh),
             FastDense(50,2))
fast_n_ode = NeuralODE(fastdudt2,p,tspan,Tsit5(),saveat=t)

function fast_predict_n_ode(p)
  fast_n_ode(u0,p)
end

function fast_loss_n_ode(p)
    pred = fast_predict_n_ode(p)
    loss = sum(abs2,ode_data .- pred)
    loss,pred
end

dudt2 = Chain((x) -> x.^3,
             Dense(2,50,tanh),
             Dense(50,2))
n_ode = NeuralODE(dudt2,tspan,Tsit5(),saveat=t)

function predict_n_ode(p)
  n_ode(u0,p)
end

function loss_n_ode(p)
    pred = predict_n_ode(p)
    loss = sum(abs2,ode_data .- pred)
    loss,pred
end

_p,re = Flux.destructure(dudt2)
@test fastdudt2(ones(2),_p) ≈ dudt2(ones(2))
@test fast_loss_n_ode(p)[1] ≈ loss_n_ode(p)[1]
@test Zygote.gradient((p)->fast_loss_n_ode(p)[1], p)[1] ≈ Zygote.gradient((p)->loss_n_ode(p)[1], p)[1]

@btime Zygote.gradient((p)->fast_loss_n_ode(p)[1], p)
@btime Zygote.gradient((p)->fast_loss_n_ode(p)[1], p)
@btime Zygote.gradient((p)->loss_n_ode(p)[1], p)
@btime Zygote.gradient((p)->loss_n_ode(p)[1], p)
```

```
  27.272 ms (181318 allocations: 16.54 MiB)
  27.328 ms (181318 allocations: 16.54 MiB)
  262.430 ms (677868 allocations: 32.83 MiB)
  260.814 ms (677868 allocations: 32.83 MiB)
```

order of magnitude performance improvement over using Flux for neural networks