### PR TITLE
stopping criterion on current loss

### DIFF
--- a/src/train.jl
+++ b/src/train.jl
@@ -25,7 +25,10 @@ function sciml_train!(loss, _θ, opt; cb = (args...) -> (), maxiters)
       first(x)
     end
     Flux.Optimise.update!(opt, ps, gs)
-    cb(θ,x...)
+    cb_call = cb(θ,x...)
+    if typeof(cb_call) == Bool && cb_call
+      break
+    end
   end
   _time = time()
   Optim.MultivariateOptimizationResults(opt,
@@ -63,7 +66,7 @@ decompose_trace(trace) = trace
 function sciml_train!(loss, θ, opt::Optim.AbstractOptimizer;
                       cb = (args...) -> (), maxiters = 0)
   local x
-  _cb(trace) = (cb(decompose_trace(trace).metadata["x"],x...);false)
+  _cb(trace) = cb(decompose_trace(trace).metadata["x"],x...)
   function optim_loss(θ)
     x = loss(θ)
     first(x)

--- a/src/train.jl
+++ b/src/train.jl
@@ -72,9 +72,8 @@ function sciml_train(loss, θ, opt::Optim.AbstractOptimizer;
     cb_call = cb(decompose_trace(trace).metadata["x"],x...)
     if !(typeof(cb_call) <: Bool)
       error("The callback should return a boolean `halt` for whether to stop the optimization process. Please see the sciml_train documentation for information.")
-    elseif cb_call
-      break
     end
+    cb_call
   end
 
   function optim_loss(θ)

--- a/src/train.jl
+++ b/src/train.jl
@@ -5,13 +5,13 @@ backpropagation and calls the optimizer `opt`.
 Takes a callback as keyword argument `cb`. For example, this will print "training"
 every 10 seconds:
 ```julia
-DiffEqFlux.sciml_train!(loss, params, data, opt,
+DiffEqFlux.sciml_train(loss, params, data, opt,
             cb = throttle(() -> println("training"), 10))
 ```
 The callback can call `Flux.stop()` to interrupt the training loop.
 Multiple optimisers and callbacks can be passed to `opt` and `cb` as arrays.
 """
-function sciml_train!(loss, _θ, opt; cb = (args...) -> (), maxiters)
+function sciml_train(loss, _θ, opt; cb = (args...) -> (false), maxiters)
   θ = copy(_θ)
   ps = Flux.params(θ)
   data = Iterators.repeated((), maxiters)
@@ -26,7 +26,9 @@ function sciml_train!(loss, _θ, opt; cb = (args...) -> (), maxiters)
     end
     Flux.Optimise.update!(opt, ps, gs)
     cb_call = cb(θ,x...)
-    if typeof(cb_call) == Bool && cb_call
+    if !(typeof(cb_call) <: Bool)
+      error("The callback should return a boolean `halt` for whether to stop the optimization process. Please see the sciml_train documentation for information.")
+    elseif cb_call
       break
     end
   end
@@ -63,10 +65,18 @@ end
 decompose_trace(trace::Optim.OptimizationTrace) = last(trace)
 decompose_trace(trace) = trace
 
-function sciml_train!(loss, θ, opt::Optim.AbstractOptimizer;
-                      cb = (args...) -> (), maxiters = 0)
+function sciml_train(loss, θ, opt::Optim.AbstractOptimizer;
+                      cb = (args...) -> (false), maxiters = 0)
   local x
-  _cb(trace) = cb(decompose_trace(trace).metadata["x"],x...)
+  function _cb(trace)
+    cb_call = cb(decompose_trace(trace).metadata["x"],x...)
+    if !(typeof(cb_call) <: Bool)
+      error("The callback should return a boolean `halt` for whether to stop the optimization process. Please see the sciml_train documentation for information.")
+    elseif cb_call
+      break
+    end
+  end
+
   function optim_loss(θ)
     x = loss(θ)
     first(x)

--- a/test/layers_sciml.jl
+++ b/test/layers_sciml.jl
@@ -26,15 +26,16 @@ grads = Zygote.gradient(loss_rd, p)
 
 cb = function (p,l)
   display(l)
+  false
 end
 
 # Display the ODE with the current parameter values.
 loss1 = loss_rd(p)
-pmin = DiffEqFlux.sciml_train!(loss_rd, p, ADAM(0.1), cb = cb, maxiters = 100)
+pmin = DiffEqFlux.sciml_train(loss_rd, p, ADAM(0.1), cb = cb, maxiters = 100)
 loss2 = loss_rd(pmin.minimizer)
 @test 10loss2 < loss1
 
-pmin = DiffEqFlux.sciml_train!(loss_rd, p, BFGS(initial_stepnorm = 0.01), cb = cb)
+pmin = DiffEqFlux.sciml_train(loss_rd, p, BFGS(initial_stepnorm = 0.01), cb = cb)
 loss2 = loss_rd(pmin.minimizer)
 @test 10loss2 < loss1
 
@@ -54,15 +55,16 @@ opt = ADAM(0.1)
 cb = function (p,l)
   display(l)
   #display(plot(solve(remake(prob,p=p),Tsit5(),saveat=0.1),ylim=(0,6)))
+  false
 end
 
 # Display the ODE with the current parameter values.
 loss1 = loss_fd(p)
-pmin = DiffEqFlux.sciml_train!(loss_fd, p, opt, cb = cb, maxiters = 100)
+pmin = DiffEqFlux.sciml_train(loss_fd, p, opt, cb = cb, maxiters = 100)
 loss2 = loss_fd(pmin.minimizer)
 @test 10loss2 < loss1
 
-pmin = DiffEqFlux.sciml_train!(loss_fd, p, BFGS(initial_stepnorm = 0.01), cb = cb)
+pmin = DiffEqFlux.sciml_train(loss_fd, p, BFGS(initial_stepnorm = 0.01), cb = cb)
 loss2 = loss_fd(pmin.minimizer)
 @test 10loss2 < loss1
 
@@ -83,14 +85,15 @@ opt = ADAM(0.1)
 cb = function (p,l)
   display(l)
   #display(plot(solve(remake(prob,p=p),Tsit5(),saveat=0.1),ylim=(0,6)))
+  false
 end
 
 # Display the ODE with the current parameter values.
 loss1 = loss_adjoint(p)
-pmin = DiffEqFlux.sciml_train!(loss_adjoint, p, opt, cb = cb, maxiters = 100)
+pmin = DiffEqFlux.sciml_train(loss_adjoint, p, opt, cb = cb, maxiters = 100)
 loss2 = loss_adjoint(pmin.minimizer)
 @test 10loss2 < loss1
 
-pmin = DiffEqFlux.sciml_train!(loss_adjoint, p, BFGS(initial_stepnorm = 0.01), cb = cb)
+pmin = DiffEqFlux.sciml_train(loss_adjoint, p, BFGS(initial_stepnorm = 0.01), cb = cb)
 loss2 = loss_adjoint(pmin.minimizer)
 @test 10loss2 < loss1

--- a/test/partial_neural.jl
+++ b/test/partial_neural.jl
@@ -26,13 +26,14 @@ l = loss_rd(θ)
 cb = function (θ,l)
   println(l)
   #display(plot(solve(remake(prob,u0=Flux.data(_x),p=Flux.data(p)),Tsit5(),saveat=0.1),ylim=(0,6)))
+  false
 end
 
 # Display the ODE with the current parameter values.
 cb(θ,l)
 
 loss1 = loss_rd(θ)
-res = DiffEqFlux.sciml_train!(loss_rd, θ, BFGS(initial_stepnorm = 0.01), cb = cb)
+res = DiffEqFlux.sciml_train(loss_rd, θ, BFGS(initial_stepnorm = 0.01), cb = cb)
 loss2 = res.minimum
 @test 10loss2 < loss1
 
@@ -65,12 +66,13 @@ l = loss_adjoint(θ)
 cb = function (θ,l)
   println(l)
   #display(plot(solve(remake(prob,p=Flux.data(p3),u0=Flux.data(u0)),Tsit5(),saveat=0.1),ylim=(0,6)))
+  false
 end
 
 # Display the ODE with the current parameter values.
 cb(θ,l)
 
 loss1 = loss_adjoint(θ)
-res = DiffEqFlux.sciml_train!(loss_adjoint, θ, BFGS(initial_stepnorm = 0.01), cb = cb)
+res = DiffEqFlux.sciml_train(loss_adjoint, θ, BFGS(initial_stepnorm = 0.01), cb = cb)
 loss2 = res.minimum
 @test 10loss2 < loss1


### PR DESCRIPTION
We can make this directly depend on the callback function (which is consistent with Optim).
For example a reasonable callback function would be
```
function cb(θ, l)
  println("Current loss: ", l)
  return l < 1e-4
end
```