### PR TITLE
auto-dualize the NeuralDE input

### DIFF
--- a/src/neural_de.jl
+++ b/src/neural_de.jl
@@ -262,7 +262,7 @@ function (n::NeuralODEMM{M})(x,p=n.p) where {M<:FastChain}
     end
     dudt_= ODEFunction(f,mass_matrix=n.mass_matrix)
     prob = ODEProblem(dudt_,dualize(x,p),n.tspan,p)
-    concrete_solve(prob,n.solver,dualize(x,p)x,p,n.args...;
+    concrete_solve(prob,n.solver,dualize(x,p),p,n.args...;
                    sensealg=InterpolatingAdjoint(
                             autojacvec=DiffEqSensitivity.ReverseDiffVJP(true)),
                             n.kwargs...)

--- a/test/newton_neural_ode.jl
+++ b/test/newton_neural_ode.jl
@@ -1,0 +1,27 @@
+using DiffEqFlux, Flux, Optim
+
+n = 10  # number of ODEs
+tspan = (0.0, 1.0)
+
+d = 5  # number of data pairs
+x_data = rand(n, 5)
+y_data = rand(n, 5)
+training_data = Iterators.cycle([(x_data[:, i], y_data[:, i]) for i in 1:d])
+
+NN = Chain(Dense(n, 10n, tanh),
+           Dense(10n, n))
+
+nODE = NeuralODE(NN, tspan, ROCK4(), reltol=1e-4, saveat=[tspan[end]])
+
+loss_function(θ, x, y) = Flux.mse(y, nODE(x, θ))
+res = DiffEqFlux.sciml_train(loss_function, nODE.p, LBFGS(), training_data)
+res = DiffEqFlux.sciml_train(loss_function, nODE.p, NewtonTrustRegion(), training_data)
+
+NN = FastChain(FastDense(n, 10n, tanh),
+               FastDense(10n, n))
+               
+nODE = NeuralODE(NN, tspan, ROCK4(), reltol=1e-4, saveat=[tspan[end]])
+
+loss_function(θ, x, y) = Flux.mse(y, nODE(x, θ))
+res = DiffEqFlux.sciml_train(loss_function, nODE.p, LBFGS(), training_data)
+res = DiffEqFlux.sciml_train(loss_function, nODE.p, NewtonTrustRegion(), training_data)

--- a/test/newton_neural_ode.jl
+++ b/test/newton_neural_ode.jl
@@ -1,6 +1,6 @@
 using DiffEqFlux, Flux, Optim, OrdinaryDiffEq
 
-n = 10  # number of ODEs
+n = 5  # number of ODEs
 tspan = (0.0, 1.0)
 
 d = 5  # number of data pairs
@@ -13,9 +13,13 @@ NN = Chain(Dense(n, 10n, tanh),
 
 nODE = NeuralODE(NN, tspan, ROCK4(), reltol=1e-4, saveat=[tspan[end]])
 
+println("Dense")
+
 loss_function(θ, x, y) = Flux.mse(y, nODE(x, θ))
 res = DiffEqFlux.sciml_train(loss_function, nODE.p, LBFGS(), training_data)
 res = DiffEqFlux.sciml_train(loss_function, nODE.p, NewtonTrustRegion(), training_data)
+
+println("FastDense")
 
 NN = FastChain(FastDense(n, 10n, tanh),
                FastDense(10n, n))

--- a/test/newton_neural_ode.jl
+++ b/test/newton_neural_ode.jl
@@ -1,4 +1,4 @@
-using DiffEqFlux, Flux, Optim
+using DiffEqFlux, Flux, Optim, OrdinaryDiffEq
 
 n = 10  # number of ODEs
 tspan = (0.0, 1.0)
@@ -19,7 +19,7 @@ res = DiffEqFlux.sciml_train(loss_function, nODE.p, NewtonTrustRegion(), trainin
 
 NN = FastChain(FastDense(n, 10n, tanh),
                FastDense(10n, n))
-               
+
 nODE = NeuralODE(NN, tspan, ROCK4(), reltol=1e-4, saveat=[tspan[end]])
 
 loss_function(θ, x, y) = Flux.mse(y, nODE(x, θ))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,7 @@ if GROUP == "All"
     @safetestset "odenet" begin include("odenet.jl") end
     @safetestset "GDP Regression Tests" begin include("gdp_regression_test.jl") end
     @safetestset "Neural DE Tests" begin include("neural_de.jl") end
-    @safetestset "Newton Neural DE Tests" begin include("newton_neural_de.jl") end
+    @safetestset "Newton Neural DE Tests" begin include("newton_neural_ode.jl") end
     @safetestset "Neural ODE MM Tests" begin include("neural_ode_mm.jl") end
     @safetestset "Fast Neural ODE Tests" begin include("fast_neural_ode.jl") end
     @safetestset "Partial Neural Tests" begin include("partial_neural.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@ if GROUP == "All"
     @safetestset "odenet" begin include("odenet.jl") end
     @safetestset "GDP Regression Tests" begin include("gdp_regression_test.jl") end
     @safetestset "Neural DE Tests" begin include("neural_de.jl") end
+    @safetestset "Newton Neural DE Tests" begin include("newton_neural_de.jl") end
     @safetestset "Neural ODE MM Tests" begin include("neural_ode_mm.jl") end
     @safetestset "Fast Neural ODE Tests" begin include("fast_neural_ode.jl") end
     @safetestset "Partial Neural Tests" begin include("partial_neural.jl") end


### PR DESCRIPTION
Otherwise users would need to do things like `nODE(eltype(θ).(x), θ)` which could get confusing, so we might as well just directly handle it since we know it will come up.