### PR TITLE
Update note on sensitivity analysis for hybrid DEs

### DIFF
--- a/docs/src/examples/bouncing_ball.md
+++ b/docs/src/examples/bouncing_ball.md
@@ -53,8 +53,13 @@ an optimal drag coefficient.
 
 ## Note on Sensitivity Methods
 
-Only some continuous adjoint sensitivities are compatible with callbacks, namely
-`BacksolveAdjoint` and `InterpolatingAdjoint`. All methods based on discrete sensitivity
-analysis via automatic differentiation, like `ReverseDiffAdjoint`, `TrackerAdjoint`, or
-`ForwardDiffAdjoint` are the methods to use (and `ReverseDiffAdjoint` is demonstrated above),
-are compatible with events. This applies to SDEs, DAEs, and DDEs as well.
+The continuous adjoint sensitivities `BacksolveAdjoint`, `InterpolatingAdjoint`,
+and `QuadratureAdjoint` are compatible with events for ODEs. `BacksolveAdjoint` and
+`InterpolatingAdjoint` can also handle events for SDEs. Use `BacksolveAdjoint` if
+the event terminates the time evolution and several states are saved. Currently,
+the continuous adjoint sensitivities do not support multiple events per time point.
+
+All methods based on discrete sensitivity analysis via automatic differentiation,
+like `ReverseDiffAdjoint`,m`TrackerAdjoint`, or `ForwardDiffAdjoint` are the methods
+to use (and `ReverseDiffAdjoint` is demonstrated above), are compatible with events.
+This applies to SDEs, DAEs, and DDEs as well.

--- a/docs/src/examples/hybrid_diffeq.md
+++ b/docs/src/examples/hybrid_diffeq.md
@@ -71,8 +71,13 @@ Flux.train!(loss_n_ode, ps, data, ADAM(0.05), cb = cba)
 
 ## Note on Sensitivity Methods
 
-Only some continuous adjoint sensitivities are compatible with callbacks, namely
-`BacksolveAdjoint` and `InterpolatingAdjoint`. All methods based on discrete sensitivity
-analysis via automatic differentiation, like `ReverseDiffAdjoint`, `TrackerAdjoint`, or
-`ForwardDiffAdjoint` are the methods to use (and `ReverseDiffAdjoint` is demonstrated above),
-are compatible with events. This applies to SDEs, DAEs, and DDEs as well.
+The continuous adjoint sensitivities `BacksolveAdjoint`, `InterpolatingAdjoint`,
+and `QuadratureAdjoint` are compatible with events for ODEs. `BacksolveAdjoint` and
+`InterpolatingAdjoint` can also handle events for SDEs. Use `BacksolveAdjoint` if
+the event terminates the time evolution and several states are saved. Currently,
+the continuous adjoint sensitivities do not support multiple events per time point.
+
+All methods based on discrete sensitivity analysis via automatic differentiation,
+like `ReverseDiffAdjoint`,m`TrackerAdjoint`, or `ForwardDiffAdjoint` are the methods
+to use (and `ReverseDiffAdjoint` is demonstrated above), are compatible with events.
+This applies to SDEs, DAEs, and DDEs as well.


### PR DESCRIPTION
https://github.com/SciML/DiffEqFlux.jl/issues/612 .

> Use `BacksolveAdjoint` if
> the event terminates the time evolution and several states are saved.

That one is very technical...I'm not sure if we want that in here. If you terminate the integration but save the time points, the `ts` range in `InterpolatingAdjoint` and `QuadratureAdjoint` will (likely) be wrong. This is like using a `saveat` which doesn't fit to the time span...Thus a wrong gradient ..


> the continuous adjoint sensitivities do not support multiple events per time point.

Just a bookkeeping issue.. This can be solved but not done yet (at least no tests). 

