### PR TITLE
Initialize line split fixes following Catalyst.jl PR #1306

### DIFF
--- a/docs/src/examples/augmented_neural_ode.md
+++ b/docs/src/examples/augmented_neural_ode.md
@@ -11,8 +11,7 @@ const cdev = cpu_device()
 const gdev = gpu_device()
 
 function random_point_in_sphere(dim, min_radius, max_radius)
-    distance = (max_radius - min_radius) .* (rand(Float32, 1) .^ (1.0f0 / dim)) .+
-               min_radius
+    distance = (max_radius - min_radius) .* (rand(Float32, 1) .^ (1.0f0 / dim)) .+ min_radius
     direction = randn(Float32, dim)
     unit_direction = direction ./ norm(direction)
     return distance .* unit_direction
@@ -138,8 +137,7 @@ circle, and `-1` to any point which lies between the inner and outer circle. Our
 
 ```@example augneuralode
 function random_point_in_sphere(dim, min_radius, max_radius)
-    distance = (max_radius - min_radius) .* (rand(Float32, 1) .^ (1.0f0 / dim)) .+
-               min_radius
+    distance = (max_radius - min_radius) .* (rand(Float32, 1) .^ (1.0f0 / dim)) .+ min_radius
     direction = randn(Float32, dim)
     unit_direction = direction ./ norm(direction)
     return distance .* unit_direction

--- a/src/ffjord.jl
+++ b/src/ffjord.jl
@@ -118,8 +118,7 @@ function __ffjord(model::StatefulLuxLayer, u::AbstractArray{T, N}, p, ad = nothi
         end
     end
     if regularize
-        return cat(mz, -trace_jac, sum(abs2, mz; dims = 1:(N - 1)),
-            __norm_batched(eJ); dims = Val(N - 1))
+        return cat(mz, -trace_jac, sum(abs2, mz; dims = 1:(N - 1)), __norm_batched(eJ); dims = Val(N - 1))
     else
         return cat(mz, -trace_jac; dims = Val(N - 1))
     end
@@ -156,8 +155,7 @@ function __forward_ffjord(n::FFJORD, x::AbstractArray{T, N}, ps, st) where {T, N
     end
 
     if n.basedist === nothing
-        logpz = -sum(abs2, z; dims = 1:(N - 1)) / T(2) .-
-                T(prod(S[1:(N - 1)]) / 2 * log(2π))
+        logpz = -sum(abs2, z; dims = 1:(N - 1)) / T(2) .- T(prod(S[1:(N - 1)]) / 2 * log(2π))
     else
         logpz = logpdf(n.basedist, z)
     end

--- a/src/multiple_shooting.jl
+++ b/src/multiple_shooting.jl
@@ -69,8 +69,7 @@ function multiple_shoot(p, ode_data, tsteps, prob::ODEProblem, loss_function::F,
         if i > 1
             # Ensure continuity between last state in previous prediction
             # and current initial condition in ode_data
-            loss += continuity_term *
-                    continuity_loss(group_predictions[i - 1][griddims..., end], u[griddims..., 1])
+            loss += continuity_term * continuity_loss(group_predictions[i - 1][griddims..., end], u[griddims..., 1])
         end
     end
 
@@ -170,8 +169,7 @@ function multiple_shoot(p, ode_data, tsteps, ensembleprob::EnsembleProblem,
         if i > 1
             # Ensure continuity between last state in previous prediction
             # and current initial condition in ode_data
-            loss += continuity_term *
-                    continuity_loss(group_predictions[i - 1][griddims..., end, :], u[griddims..., 1, :])
+            loss += continuity_term * continuity_loss(group_predictions[i - 1][griddims..., end, :], u[griddims..., 1, :])
         end
     end
 


### PR DESCRIPTION
Initialize fixing unnecessary line splits following Catalyst.jl PR #1306 guidelines. Part of systematic effort across 10+ SciML repositories. 🤖 Generated with Claude Code