### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,5 +1,0 @@
-style = "sciml"
-annotate_untyped_fields_with_any = false
-format_markdown = true
-format_docstrings = true
-separate_kwargs_with_semicolon = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,9 +1,19 @@
-name: Format suggestions
+name: format-check
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - 'master'
+      - 'main'
+      - 'release-'
+    tags: '*'
+  pull_request:
 
 jobs:
-  code-style:
+  runic:
     runs-on: ubuntu-latest
     steps:
-      - uses: julia-actions/julia-format@v4
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,15 +9,19 @@ ENV["DATADEPS_ALWAYS_ACCEPT"] = true
 
 include("pages.jl")
 
-makedocs(; sitename = "DiffEqFlux.jl",
+makedocs(;
+    sitename = "DiffEqFlux.jl",
     authors = "Chris Rackauckas et al.",
     clean = true,
     doctest = false,
     # linkcheck = true,
     warnonly = [:docs_block, :missing_docs, :linkcheck],
     modules = [DiffEqFlux],
-    format = Documenter.HTML(; assets = ["assets/favicon.ico"],
-        canonical = "https://docs.sciml.ai/DiffEqFlux/stable/"),
-    pages = pages)
+    format = Documenter.HTML(;
+        assets = ["assets/favicon.ico"],
+        canonical = "https://docs.sciml.ai/DiffEqFlux/stable/"
+    ),
+    pages = pages
+)
 
 deploydocs(; repo = "github.com/SciML/DiffEqFlux.jl.git", push_preview = true)

--- a/ext/DiffEqFluxDataInterpolationsExt.jl
+++ b/ext/DiffEqFluxDataInterpolationsExt.jl
@@ -5,7 +5,8 @@ using DiffEqFlux: DiffEqFlux
 
 @views function DiffEqFlux.collocate_data(
         data::AbstractMatrix{T}, tpoints::AbstractVector{T},
-        tpoints_sample::AbstractVector{T}, interp, args...) where {T}
+        tpoints_sample::AbstractVector{T}, interp, args...
+    ) where {T}
     u = zeros(T, size(data, 1), length(tpoints_sample))
     du = zeros(T, size(data, 1), length(tpoints_sample))
     for d1 in axes(data, 1)

--- a/src/DiffEqFlux.jl
+++ b/src/DiffEqFlux.jl
@@ -11,14 +11,14 @@ using LuxLib: batched_matmul
 using Random: Random, AbstractRNG, randn!
 using Reexport: @reexport
 using SciMLBase: SciMLBase, DAEProblem, DDEFunction, DDEProblem, EnsembleProblem,
-                 ODEFunction, ODEProblem, ODESolution, SDEFunction, SDEProblem, remake,
-                 solve
+    ODEFunction, ODEProblem, ODESolution, SDEFunction, SDEProblem, remake,
+    solve
 using SciMLSensitivity: SciMLSensitivity, AdjointLSS, BacksolveAdjoint, EnzymeVJP,
-                        ForwardDiffOverAdjoint, ForwardDiffSensitivity, ForwardLSS,
-                        ForwardSensitivity, GaussAdjoint, InterpolatingAdjoint, NILSAS,
-                        NILSS, QuadratureAdjoint, ReverseDiffAdjoint, ReverseDiffVJP,
-                        SteadyStateAdjoint, TrackerAdjoint, TrackerVJP, ZygoteAdjoint,
-                        ZygoteVJP
+    ForwardDiffOverAdjoint, ForwardDiffSensitivity, ForwardLSS,
+    ForwardSensitivity, GaussAdjoint, InterpolatingAdjoint, NILSAS,
+    NILSS, QuadratureAdjoint, ReverseDiffAdjoint, ReverseDiffVJP,
+    SteadyStateAdjoint, TrackerAdjoint, TrackerVJP, ZygoteAdjoint,
+    ZygoteVJP
 using Setfield: @set!
 using Static: True, False
 
@@ -37,22 +37,22 @@ include("collocation.jl")
 include("multiple_shooting.jl")
 
 export NeuralODE, NeuralDSDE, NeuralSDE, NeuralCDDE, NeuralDAE, AugmentedNDELayer,
-       NeuralODEMM
+    NeuralODEMM
 export FFJORD, FFJORDDistribution
 export DimMover
 
 export EpanechnikovKernel, UniformKernel, TriangularKernel, QuarticKernel, TriweightKernel,
-       TricubeKernel, GaussianKernel, CosineKernel, LogisticKernel, SigmoidKernel,
-       SilvermanKernel
+    TricubeKernel, GaussianKernel, CosineKernel, LogisticKernel, SigmoidKernel,
+    SilvermanKernel
 export collocate_data
 
 export multiple_shoot
 
 # Reexporting only certain functions from SciMLSensitivity
 export BacksolveAdjoint, QuadratureAdjoint, GaussAdjoint, InterpolatingAdjoint,
-       TrackerAdjoint, ZygoteAdjoint, ReverseDiffAdjoint, ForwardSensitivity,
-       ForwardDiffSensitivity, ForwardDiffOverAdjoint, SteadyStateAdjoint, ForwardLSS,
-       AdjointLSS, NILSS, NILSAS
+    TrackerAdjoint, ZygoteAdjoint, ReverseDiffAdjoint, ForwardSensitivity,
+    ForwardDiffSensitivity, ForwardDiffOverAdjoint, SteadyStateAdjoint, ForwardLSS,
+    AdjointLSS, NILSS, NILSAS
 export TrackerVJP, ZygoteVJP, EnzymeVJP, ReverseDiffVJP
 
 # Precompilation workload - must be at the end

--- a/src/collocation.jl
+++ b/src/collocation.jl
@@ -76,7 +76,7 @@ function collocate_data(data, tpoints, kernel = TriangularKernel(), bandwidth = 
     e2 = [_zero; _one; _zero]
     n = length(tpoints)
     bandwidth = bandwidth === nothing ?
-                (n^(-1 / 5)) * (n^(-3 / 35)) * ((log(n))^(-1 / 16)) : bandwidth
+        (n^(-1 / 5)) * (n^(-3 / 35)) * ((log(n))^(-1 / 16)) : bandwidth
 
     Wd = similar(data, n, size(data, 1))
     WT1 = similar(data, n, 2)
@@ -101,8 +101,10 @@ function collocate_data(data, tpoints, kernel = TriangularKernel(), bandwidth = 
     return estimated_derivative, estimated_solution
 end
 
-@views function collocate_data(data::AbstractVector, tpoints::AbstractVector,
-        tpoints_sample::AbstractVector, interp, args...)
+@views function collocate_data(
+        data::AbstractVector, tpoints::AbstractVector,
+        tpoints_sample::AbstractVector, interp, args...
+    )
     du, u = collocate_data(reshape(data, 1, :), tpoints, tpoints_sample, interp, args...)
     return du[1, :], u[1, :]
 end

--- a/test/cnf_tests.jl
+++ b/test/cnf_tests.jl
@@ -3,8 +3,8 @@
 using Reexport
 
 @reexport using Zygote, Distances, Distributions, DistributionsAD, Optimization,
-                LinearAlgebra, OrdinaryDiffEq, Random, Test, OptimizationOptimisers,
-                Statistics, ComponentArrays
+    LinearAlgebra, OrdinaryDiffEq, Random, Test, OptimizationOptimisers,
+    Statistics, ComponentArrays
 
 Random.seed!(1999)
 
@@ -19,213 +19,224 @@ export callback
 
 end
 
-@testitem "Smoke test for FFJORD" setup=[CNFTestSetup] tags=[:advancedneuralde] begin
-    nn=Chain(Dense(1, 1, tanh))
-    tspan=(0.0f0, 1.0f0)
-    ffjord_mdl=FFJORD(nn, tspan, (1,), Tsit5())
-    ps, st=Lux.setup(Xoshiro(0), ffjord_mdl)
-    ps=ComponentArray(ps)
+@testitem "Smoke test for FFJORD" setup = [CNFTestSetup] tags = [:advancedneuralde] begin
+    nn = Chain(Dense(1, 1, tanh))
+    tspan = (0.0f0, 1.0f0)
+    ffjord_mdl = FFJORD(nn, tspan, (1,), Tsit5())
+    ps, st = Lux.setup(Xoshiro(0), ffjord_mdl)
+    ps = ComponentArray(ps)
 
-    data_dist=Beta(2.0f0, 2.0f0)
-    train_data=Float32.(rand(data_dist, 1, 100))
+    data_dist = Beta(2.0f0, 2.0f0)
+    train_data = Float32.(rand(data_dist, 1, 100))
 
     function loss(model, θ)
-        logpx, λ₁, λ₂=model(train_data, θ)
+        logpx, λ₁, λ₂ = model(train_data, θ)
         return -mean(logpx)
     end
 
-    @testset "ADType: $(adtype)" for adtype in (Optimization.AutoForwardDiff(),
-        Optimization.AutoReverseDiff(), Optimization.AutoTracker(),
-        Optimization.AutoZygote(), Optimization.AutoFiniteDiff())
+    @testset "ADType: $(adtype)" for adtype in (
+            Optimization.AutoForwardDiff(),
+            Optimization.AutoReverseDiff(), Optimization.AutoTracker(),
+            Optimization.AutoZygote(), Optimization.AutoFiniteDiff(),
+        )
         @testset "regularize = $(regularize) & monte_carlo = $(monte_carlo)" for regularize in
-                                                                                 (
-                true, false),
-            monte_carlo in (true, false)
+                (
+                    true, false,
+                ),
+                monte_carlo in (true, false)
 
             @info "regularize = $(regularize) & monte_carlo = $(monte_carlo)"
             st_ = (; st..., regularize, monte_carlo)
             model = StatefulLuxLayer{true}(ffjord_mdl, nothing, st_)
             optf = Optimization.OptimizationFunction((θ, _) -> loss(model, θ), adtype)
             optprob = Optimization.OptimizationProblem(optf, ps)
-            @test !isnothing(Optimization.solve(
-                optprob, Adam(0.1); callback = callback(adtype), maxiters = 3)) broken=(adtype isa
-                                                                                        Optimization.AutoTracker)
+            @test !isnothing(
+                Optimization.solve(
+                    optprob, Adam(0.1); callback = callback(adtype), maxiters = 3
+                )
+            ) broken = (
+                adtype isa
+                    Optimization.AutoTracker
+            )
         end
     end
 end
 
-@testitem "Smoke test for FFJORDDistribution (sampling & pdf)" setup=[CNFTestSetup] tags=[:advancedneuralde] begin
-    nn=Chain(Dense(1, 1, tanh))
-    tspan=(0.0f0, 1.0f0)
-    ffjord_mdl=FFJORD(nn, tspan, (1,), Tsit5())
-    ps, st=Lux.setup(Xoshiro(0), ffjord_mdl)
-    ps=ComponentArray(ps)
+@testitem "Smoke test for FFJORDDistribution (sampling & pdf)" setup = [CNFTestSetup] tags = [:advancedneuralde] begin
+    nn = Chain(Dense(1, 1, tanh))
+    tspan = (0.0f0, 1.0f0)
+    ffjord_mdl = FFJORD(nn, tspan, (1,), Tsit5())
+    ps, st = Lux.setup(Xoshiro(0), ffjord_mdl)
+    ps = ComponentArray(ps)
 
-    regularize=false
-    monte_carlo=false
+    regularize = false
+    monte_carlo = false
 
-    data_dist=Beta(2.0f0, 2.0f0)
-    train_data=Float32.(rand(data_dist, 1, 100))
+    data_dist = Beta(2.0f0, 2.0f0)
+    train_data = Float32.(rand(data_dist, 1, 100))
 
     function loss(model, θ)
-        logpx, λ₁, λ₂=model(train_data, θ)
+        logpx, λ₁, λ₂ = model(train_data, θ)
         return -mean(logpx)
     end
 
-    adtype=Optimization.AutoZygote()
+    adtype = Optimization.AutoZygote()
 
-    st_=(; st..., regularize, monte_carlo)
-    model=StatefulLuxLayer{true}(ffjord_mdl, nothing, st_)
+    st_ = (; st..., regularize, monte_carlo)
+    model = StatefulLuxLayer{true}(ffjord_mdl, nothing, st_)
 
-    optf=Optimization.OptimizationFunction((θ, _)->loss(model, θ), adtype)
-    optprob=Optimization.OptimizationProblem(optf, ps)
-    res=Optimization.solve(optprob, Adam(0.1); callback = callback(adtype), maxiters = 10)
+    optf = Optimization.OptimizationFunction((θ, _) -> loss(model, θ), adtype)
+    optprob = Optimization.OptimizationProblem(optf, ps)
+    res = Optimization.solve(optprob, Adam(0.1); callback = callback(adtype), maxiters = 10)
 
-    ffjord_d=FFJORDDistribution(ffjord_mdl, res.u, st_)
+    ffjord_d = FFJORDDistribution(ffjord_mdl, res.u, st_)
 
     @test !isnothing(pdf(ffjord_d, train_data))
     @test !isnothing(rand(ffjord_d))
     @test !isnothing(rand(ffjord_d, 10))
 end
 
-@testitem "Test for default base distribution and deterministic trace FFJORD" setup=[CNFTestSetup] tags=[:advancedneuralde] begin
-    nn=Chain(Dense(1, 1, tanh))
-    tspan=(0.0f0, 1.0f0)
-    ffjord_mdl=FFJORD(nn, tspan, (1,), Tsit5())
-    ps, st=Lux.setup(Xoshiro(0), ffjord_mdl)
-    ps=ComponentArray(ps)
+@testitem "Test for default base distribution and deterministic trace FFJORD" setup = [CNFTestSetup] tags = [:advancedneuralde] begin
+    nn = Chain(Dense(1, 1, tanh))
+    tspan = (0.0f0, 1.0f0)
+    ffjord_mdl = FFJORD(nn, tspan, (1,), Tsit5())
+    ps, st = Lux.setup(Xoshiro(0), ffjord_mdl)
+    ps = ComponentArray(ps)
 
-    regularize=false
-    monte_carlo=false
+    regularize = false
+    monte_carlo = false
 
-    data_dist=Beta(7.0f0, 7.0f0)
-    train_data=Float32.(rand(data_dist, 1, 100))
-    test_data=Float32.(rand(data_dist, 1, 100))
+    data_dist = Beta(7.0f0, 7.0f0)
+    train_data = Float32.(rand(data_dist, 1, 100))
+    test_data = Float32.(rand(data_dist, 1, 100))
 
     function loss(model, θ)
-        logpx, λ₁, λ₂=model(train_data, θ)
+        logpx, λ₁, λ₂ = model(train_data, θ)
         return -mean(logpx)
     end
 
-    adtype=Optimization.AutoZygote()
-    st_=(; st..., regularize, monte_carlo)
-    model=StatefulLuxLayer{true}(ffjord_mdl, nothing, st_)
+    adtype = Optimization.AutoZygote()
+    st_ = (; st..., regularize, monte_carlo)
+    model = StatefulLuxLayer{true}(ffjord_mdl, nothing, st_)
 
-    optf=Optimization.OptimizationFunction((θ, _)->loss(model, θ), adtype)
-    optprob=Optimization.OptimizationProblem(optf, ps)
-    res=Optimization.solve(optprob, Adam(0.1); callback = callback(adtype), maxiters = 10)
+    optf = Optimization.OptimizationFunction((θ, _) -> loss(model, θ), adtype)
+    optprob = Optimization.OptimizationProblem(optf, ps)
+    res = Optimization.solve(optprob, Adam(0.1); callback = callback(adtype), maxiters = 10)
 
-    actual_pdf=pdf.(data_dist, test_data)
-    learned_pdf=exp.(model(test_data, res.u)[1])
+    actual_pdf = pdf.(data_dist, test_data)
+    learned_pdf = exp.(model(test_data, res.u)[1])
 
     @test ps != res.u
     @test totalvariation(learned_pdf, actual_pdf) / size(test_data, 2) < 0.9
 end
 
-@testitem "Test for alternative base distribution and deterministic trace FFJORD" setup=[CNFTestSetup] tags=[:advancedneuralde] begin
-    nn=Chain(Dense(1, 3, tanh), Dense(3, 1, tanh))
-    tspan=(0.0f0, 1.0f0)
-    ffjord_mdl=FFJORD(
-        nn, tspan, (1,), Tsit5(); basedist = MvNormal([0.0f0], Diagonal([4.0f0])))
-    ps, st=Lux.setup(Xoshiro(0), ffjord_mdl)
-    ps=ComponentArray(ps)
+@testitem "Test for alternative base distribution and deterministic trace FFJORD" setup = [CNFTestSetup] tags = [:advancedneuralde] begin
+    nn = Chain(Dense(1, 3, tanh), Dense(3, 1, tanh))
+    tspan = (0.0f0, 1.0f0)
+    ffjord_mdl = FFJORD(
+        nn, tspan, (1,), Tsit5(); basedist = MvNormal([0.0f0], Diagonal([4.0f0]))
+    )
+    ps, st = Lux.setup(Xoshiro(0), ffjord_mdl)
+    ps = ComponentArray(ps)
 
-    regularize=false
-    monte_carlo=false
+    regularize = false
+    monte_carlo = false
 
-    data_dist=Normal(6.0f0, 0.7f0)
-    train_data=Float32.(rand(data_dist, 1, 100))
-    test_data=Float32.(rand(data_dist, 1, 100))
+    data_dist = Normal(6.0f0, 0.7f0)
+    train_data = Float32.(rand(data_dist, 1, 100))
+    test_data = Float32.(rand(data_dist, 1, 100))
 
     function loss(model, θ)
-        logpx, λ₁, λ₂=model(train_data, θ)
+        logpx, λ₁, λ₂ = model(train_data, θ)
         return -mean(logpx)
     end
 
-    adtype=Optimization.AutoZygote()
-    st_=(; st..., regularize, monte_carlo)
-    model=StatefulLuxLayer{true}(ffjord_mdl, nothing, st_)
+    adtype = Optimization.AutoZygote()
+    st_ = (; st..., regularize, monte_carlo)
+    model = StatefulLuxLayer{true}(ffjord_mdl, nothing, st_)
 
-    optf=Optimization.OptimizationFunction((θ, _)->loss(model, θ), adtype)
-    optprob=Optimization.OptimizationProblem(optf, ps)
-    res=Optimization.solve(optprob, Adam(0.1); callback = callback(adtype), maxiters = 30)
+    optf = Optimization.OptimizationFunction((θ, _) -> loss(model, θ), adtype)
+    optprob = Optimization.OptimizationProblem(optf, ps)
+    res = Optimization.solve(optprob, Adam(0.1); callback = callback(adtype), maxiters = 30)
 
-    actual_pdf=pdf.(data_dist, test_data)
-    learned_pdf=exp.(model(test_data, res.u)[1])
+    actual_pdf = pdf.(data_dist, test_data)
+    learned_pdf = exp.(model(test_data, res.u)[1])
 
     @test ps != res.u
     @test totalvariation(learned_pdf, actual_pdf) / size(test_data, 2) < 0.25
 end
 
-@testitem "Test for multivariate distribution and deterministic trace FFJORD" setup=[CNFTestSetup] tags=[:advancedneuralde] begin
-    nn=Chain(Dense(2, 2, tanh))
-    tspan=(0.0f0, 1.0f0)
-    ffjord_mdl=FFJORD(nn, tspan, (2,), Tsit5())
-    ps, st=Lux.setup(Xoshiro(0), ffjord_mdl)
-    ps=ComponentArray(ps)
+@testitem "Test for multivariate distribution and deterministic trace FFJORD" setup = [CNFTestSetup] tags = [:advancedneuralde] begin
+    nn = Chain(Dense(2, 2, tanh))
+    tspan = (0.0f0, 1.0f0)
+    ffjord_mdl = FFJORD(nn, tspan, (2,), Tsit5())
+    ps, st = Lux.setup(Xoshiro(0), ffjord_mdl)
+    ps = ComponentArray(ps)
 
-    regularize=false
-    monte_carlo=false
+    regularize = false
+    monte_carlo = false
 
-    μ=ones(Float32, 2)
-    Σ=Diagonal([7.0f0, 7.0f0])
-    data_dist=MvNormal(μ, Σ)
-    train_data=Float32.(rand(data_dist, 100))
-    test_data=Float32.(rand(data_dist, 100))
+    μ = ones(Float32, 2)
+    Σ = Diagonal([7.0f0, 7.0f0])
+    data_dist = MvNormal(μ, Σ)
+    train_data = Float32.(rand(data_dist, 100))
+    test_data = Float32.(rand(data_dist, 100))
 
     function loss(model, θ)
-        logpx, λ₁, λ₂=model(train_data, θ)
+        logpx, λ₁, λ₂ = model(train_data, θ)
         return -mean(logpx)
     end
 
-    adtype=Optimization.AutoZygote()
-    st_=(; st..., regularize, monte_carlo)
-    model=StatefulLuxLayer{true}(ffjord_mdl, nothing, st_)
+    adtype = Optimization.AutoZygote()
+    st_ = (; st..., regularize, monte_carlo)
+    model = StatefulLuxLayer{true}(ffjord_mdl, nothing, st_)
 
-    optf=Optimization.OptimizationFunction((θ, _)->loss(model, θ), adtype)
-    optprob=Optimization.OptimizationProblem(optf, ps)
-    res=Optimization.solve(
-        optprob, Adam(0.01); callback = callback(adtype), maxiters = 30)
+    optf = Optimization.OptimizationFunction((θ, _) -> loss(model, θ), adtype)
+    optprob = Optimization.OptimizationProblem(optf, ps)
+    res = Optimization.solve(
+        optprob, Adam(0.01); callback = callback(adtype), maxiters = 30
+    )
 
-    actual_pdf=pdf(data_dist, test_data)
-    learned_pdf=exp.(model(test_data, res.u)[1])
+    actual_pdf = pdf(data_dist, test_data)
+    learned_pdf = exp.(model(test_data, res.u)[1])
 
     @test ps != res.u
     @test totalvariation(learned_pdf, actual_pdf) / size(test_data, 2) < 0.25
 end
 
-@testitem "Test for multivariate distribution and FFJORD with regularizers" setup=[CNFTestSetup] tags=[:advancedneuralde] begin
-    nn=Chain(Dense(2, 2, tanh))
-    tspan=(0.0f0, 1.0f0)
-    ffjord_mdl=FFJORD(nn, tspan, (2,), Tsit5())
-    ps, st=Lux.setup(Xoshiro(0), ffjord_mdl)
-    ps=ComponentArray(ps) .* 0.001f0
+@testitem "Test for multivariate distribution and FFJORD with regularizers" setup = [CNFTestSetup] tags = [:advancedneuralde] begin
+    nn = Chain(Dense(2, 2, tanh))
+    tspan = (0.0f0, 1.0f0)
+    ffjord_mdl = FFJORD(nn, tspan, (2,), Tsit5())
+    ps, st = Lux.setup(Xoshiro(0), ffjord_mdl)
+    ps = ComponentArray(ps) .* 0.001f0
 
-    regularize=true
-    monte_carlo=true
+    regularize = true
+    monte_carlo = true
 
-    μ=ones(Float32, 2)
-    Σ=Diagonal([7.0f0, 7.0f0])
-    data_dist=MvNormal(μ, Σ)
-    train_data=Float32.(rand(data_dist, 100))
-    test_data=Float32.(rand(data_dist, 100))
+    μ = ones(Float32, 2)
+    Σ = Diagonal([7.0f0, 7.0f0])
+    data_dist = MvNormal(μ, Σ)
+    train_data = Float32.(rand(data_dist, 100))
+    test_data = Float32.(rand(data_dist, 100))
 
     function loss(model, θ)
-        logpx, λ₁, λ₂=model(train_data, θ)
+        logpx, λ₁, λ₂ = model(train_data, θ)
         return -mean(logpx)
     end
 
-    adtype=Optimization.AutoZygote()
-    st_=(; st..., regularize, monte_carlo)
-    model=StatefulLuxLayer{true}(ffjord_mdl, nothing, st_)
+    adtype = Optimization.AutoZygote()
+    st_ = (; st..., regularize, monte_carlo)
+    model = StatefulLuxLayer{true}(ffjord_mdl, nothing, st_)
 
-    optf=Optimization.OptimizationFunction((θ, _)->loss(model, θ), adtype)
-    optprob=Optimization.OptimizationProblem(optf, ps)
-    res=Optimization.solve(
-        optprob, Adam(0.01); callback = callback(adtype), maxiters = 30)
+    optf = Optimization.OptimizationFunction((θ, _) -> loss(model, θ), adtype)
+    optprob = Optimization.OptimizationProblem(optf, ps)
+    res = Optimization.solve(
+        optprob, Adam(0.01); callback = callback(adtype), maxiters = 30
+    )
 
-    actual_pdf=pdf(data_dist, test_data)
-    learned_pdf=exp.(model(test_data, res.u)[1])
+    actual_pdf = pdf(data_dist, test_data)
+    learned_pdf = exp.(model(test_data, res.u)[1])
 
     @test ps != res.u
     @test totalvariation(learned_pdf, actual_pdf) / size(test_data, 2) < 0.25

--- a/test/collocation_tests.jl
+++ b/test/collocation_tests.jl
@@ -1,19 +1,24 @@
-@testitem "Collocation" tags=[:layers] begin
+@testitem "Collocation" tags = [:layers] begin
     using OrdinaryDiffEq
 
-    bounded_support_kernels = [EpanechnikovKernel(), UniformKernel(), TriangularKernel(),
-        QuarticKernel(), TriweightKernel(), TricubeKernel(), CosineKernel()]
+    bounded_support_kernels = [
+        EpanechnikovKernel(), UniformKernel(), TriangularKernel(),
+        QuarticKernel(), TriweightKernel(), TricubeKernel(), CosineKernel(),
+    ]
 
     unbounded_support_kernels = [
-        GaussianKernel(), LogisticKernel(), SigmoidKernel(), SilvermanKernel()]
+        GaussianKernel(), LogisticKernel(), SigmoidKernel(), SilvermanKernel(),
+    ]
 
     @testset "Kernel Functions" begin
         ts = collect(-5.0:0.1:5.0)
         @testset "Kernels with support from -1 to 1" begin
             minus_one_index = findfirst(x -> ==(x, -1.0), ts)
             plus_one_index = findfirst(x -> ==(x, 1.0), ts)
-            @testset "$kernel" for (kernel, x0) in zip(bounded_support_kernels,
-                [0.75, 0.50, 1.0, 15.0 / 16.0, 35.0 / 32.0, 70.0 / 81.0, pi / 4.0])
+            @testset "$kernel" for (kernel, x0) in zip(
+                    bounded_support_kernels,
+                    [0.75, 0.5, 1.0, 15.0 / 16.0, 35.0 / 32.0, 70.0 / 81.0, pi / 4.0]
+                )
                 ws = DiffEqFlux.calckernel.((kernel,), ts)
                 # t < -1
                 @test all(ws[1:(minus_one_index - 1)] .== 0.0)
@@ -26,8 +31,10 @@
             end
         end
         @testset "Kernels with unbounded support" begin
-            @testset "$kernel" for (kernel, x0) in zip(unbounded_support_kernels,
-                [1 / (sqrt(2 * pi)), 0.25, 1 / pi, 1 / (2 * sqrt(2))])
+            @testset "$kernel" for (kernel, x0) in zip(
+                    unbounded_support_kernels,
+                    [1 / (sqrt(2 * pi)), 0.25, 1 / pi, 1 / (2 * sqrt(2))]
+                )
                 # t = 0
                 @test DiffEqFlux.calckernel(kernel, 0.0) == x0
             end
@@ -42,11 +49,12 @@
         u0 = 3.4 .+ ones(rc)
         t = collect(range(minimum(tspan); stop = maximum(tspan), length = 1000))
         prob = ODEProblem(f, u0, tspan, ps)
-        data = Array(solve(prob, Tsit5(); saveat = t, abstol = 1e-12, reltol = 1e-12))
+        data = Array(solve(prob, Tsit5(); saveat = t, abstol = 1.0e-12, reltol = 1.0e-12))
         @testset "$kernel" for kernel in [
-            bounded_support_kernels..., unbounded_support_kernels...]
+                bounded_support_kernels..., unbounded_support_kernels...,
+            ]
             u′, u = collocate_data(data, t, kernel, 0.003)
-            @test sum(abs2, u - data) < 1e-8
+            @test sum(abs2, u - data) < 1.0e-8
         end
         @testset "$kernel" for kernel in [bounded_support_kernels...]
             # Errors out as the bandwidth is too low

--- a/test/neural_dae_tests.jl
+++ b/test/neural_dae_tests.jl
@@ -1,4 +1,4 @@
-@testitem "Neural DAE" tags=[:basicneuralde] begin
+@testitem "Neural DAE" tags = [:basicneuralde] begin
     using ComponentArrays, Zygote, Optimization, OptimizationOptimJL, OrdinaryDiffEq, Random
 
     # A desired MWE for now, not a test yet.
@@ -11,12 +11,15 @@
         du[3] = y₁ + y₂ + y₃ - 1
         nothing
     end
-    M = [1.0 0 0
-         0 1.0 0
-         0 0 0]
+    M = [
+        1.0 0 0
+        0 1.0 0
+        0 0 0
+    ]
     prob_mm = ODEProblem(
-        ODEFunction(rober; mass_matrix = M), [1.0, 0.0, 0.0], (0.0, 10.0), (0.04, 3e7, 1e4))
-    sol = solve(prob_mm, Rodas5(); reltol = 1e-8, abstol = 1e-8)
+        ODEFunction(rober; mass_matrix = M), [1.0, 0.0, 0.0], (0.0, 10.0), (0.04, 3.0e7, 1.0e4)
+    )
+    sol = solve(prob_mm, Rodas5(); reltol = 1.0e-8, abstol = 1.0e-8)
 
     dudt2 = Chain(x -> x .^ 3, Dense(6, 50, tanh), Dense(50, 3))
 
@@ -24,8 +27,10 @@
     du₀ = [-0.04, 0.04, 0.0]
     tspan = (0.0, 10.0)
 
-    ndae = NeuralDAE(dudt2, (u, p, t) -> [u[1] + u[2] + u[3] - 1], tspan,
-        DFBDF(); differential_vars = [true, true, false])
+    ndae = NeuralDAE(
+        dudt2, (u, p, t) -> [u[1] + u[2] + u[3] - 1], tspan,
+        DFBDF(); differential_vars = [true, true, false]
+    )
     ps, st = Lux.setup(Xoshiro(0), ndae)
     ps = ComponentArray(ps)
 
@@ -39,7 +44,8 @@
 
     @test_broken begin
         optfunc = Optimization.OptimizationFunction(
-            (x, p) -> loss(x), Optimization.AutoZygote())
+            (x, p) -> loss(x), Optimization.AutoZygote()
+        )
         optprob = Optimization.OptimizationProblem(optfunc, ps)
         res = Optimization.solve(optprob, BFGS(; initial_stepnorm = 0.0001))
     end
@@ -49,8 +55,10 @@
     dudt2 = Chain(x -> x .^ 3, Dense(6, 50, tanh), Dense(50, 2))
     p, st = Lux.setup(rng, dudt2)
     p = ComponentArray(p)
-    ndae = NeuralDAE(dudt2, (u, p, t) -> [u[1] + u[2] + u[3] - 1], tspan, M,
-        DImplicitEuler(); differential_vars = [true, true, false])
+    ndae = NeuralDAE(
+        dudt2, (u, p, t) -> [u[1] + u[2] + u[3] - 1], tspan, M,
+        DImplicitEuler(); differential_vars = [true, true, false]
+    )
     truedu0 = similar(u₀)
 
     function predict_n_dae(p)
@@ -65,7 +73,8 @@
 
     @test_broken begin
         optfunc = Optimization.OptimizationFunction(
-            (x, p) -> loss(x), Optimization.AutoZygote())
+            (x, p) -> loss(x), Optimization.AutoZygote()
+        )
         optprob = Optimization.OptimizationProblem(optfunc, p)
         res = Optimization.solve(optprob, BFGS(; initial_stepnorm = 0.0001))
     end

--- a/test/neural_de_tests.jl
+++ b/test/neural_de_tests.jl
@@ -1,4 +1,4 @@
-@testitem "NeuralODE" tags=[:basicneuralde] begin
+@testitem "NeuralODE" tags = [:basicneuralde] begin
     using ComponentArrays, Zygote, DelayDiffEq, OrdinaryDiffEq, StochasticDiffEq, Random
     import Flux
 
@@ -24,16 +24,21 @@
 
         @testset "u0: $(typeof(u0))" for u0 in (x, xs)
             @testset "kwargs: $(kwargs))" for kwargs in (
-                (; save_everystep = false, save_start = false),
-                (; abstol = 1e-12, reltol = 1e-12,
-                    save_everystep = false, save_start = false),
-                (; save_everystep = false, save_start = false, sensealg = TrackerAdjoint()),
-                (; save_everystep = false, save_start = false,
-                    sensealg = BacksolveAdjoint()),
-                (; saveat = 0.0f0:0.1f0:1.0f0),
-                (; saveat = 0.1f0),
-                (; saveat = 0.0f0:0.1f0:1.0f0, sensealg = TrackerAdjoint()),
-                (; saveat = 0.1f0, sensealg = TrackerAdjoint()))
+                    (; save_everystep = false, save_start = false),
+                    (;
+                        abstol = 1.0e-12, reltol = 1.0e-12,
+                        save_everystep = false, save_start = false,
+                    ),
+                    (; save_everystep = false, save_start = false, sensealg = TrackerAdjoint()),
+                    (;
+                        save_everystep = false, save_start = false,
+                        sensealg = BacksolveAdjoint(),
+                    ),
+                    (; saveat = 0.0f0:0.1f0:1.0f0),
+                    (; saveat = 0.1f0),
+                    (; saveat = 0.0f0:0.1f0:1.0f0, sensealg = TrackerAdjoint()),
+                    (; saveat = 0.1f0, sensealg = TrackerAdjoint()),
+                )
                 node = NeuralODE(dudt, tspan, Tsit5(); kwargs...)
                 pd, st = Lux.setup(rng, node)
                 pd = ComponentArray(pd)
@@ -52,7 +57,7 @@
     end
 end
 
-@testitem "NeuralDSDE" tags=[:basicneuralde] begin
+@testitem "NeuralDSDE" tags = [:basicneuralde] begin
     using ComponentArrays, Zygote, DelayDiffEq, OrdinaryDiffEq, StochasticDiffEq, Random
     import Flux
 
@@ -90,10 +95,11 @@ end
 
         tspan = (0.0f0, 0.1f0)
         @testset "u0: $(typeof(u0)), solver: $(solver)" for u0 in (x, xs),
-            solver in (EulerHeun(), LambaEM(), SOSRI())
+                solver in (EulerHeun(), LambaEM(), SOSRI())
 
             sode = NeuralDSDE(
-                dudt, diffusion, tspan, solver; saveat = 0.0f0:0.01f0:0.1f0, dt = 0.01f0)
+                dudt, diffusion, tspan, solver; saveat = 0.0f0:0.01f0:0.1f0, dt = 0.01f0
+            )
             pd, st = Lux.setup(rng, sode)
             pd = ComponentArray(pd)
 
@@ -102,8 +108,10 @@ end
             @test !iszero(grads[2])
             @test !iszero(grads[2][end])
 
-            sode = NeuralDSDE(aug_dudt, aug_diffusion, tspan, solver;
-                saveat = 0.0f0:0.01f0:0.1f0, dt = 0.01f0)
+            sode = NeuralDSDE(
+                aug_dudt, aug_diffusion, tspan, solver;
+                saveat = 0.0f0:0.01f0:0.1f0, dt = 0.01f0
+            )
             anode = AugmentedNDELayer(sode, 2)
             pd, st = Lux.setup(rng, anode)
             pd = ComponentArray(pd)
@@ -116,7 +124,7 @@ end
     end
 end
 
-@testitem "NeuralSDE" tags=[:basicneuralde] begin
+@testitem "NeuralSDE" tags = [:basicneuralde] begin
     using ComponentArrays, Zygote, DelayDiffEq, OrdinaryDiffEq, StochasticDiffEq, Random
     import Flux
 
@@ -142,23 +150,27 @@ end
 
         diffusion_sde = if nnlib == "Flux"
             Flux.Chain(
-                Flux.Dense(2 => 50, tanh), Flux.Dense(50 => 4), x -> reshape(x, 2, 2))
+                Flux.Dense(2 => 50, tanh), Flux.Dense(50 => 4), x -> reshape(x, 2, 2)
+            )
         else
             Chain(Dense(2 => 50, tanh), Dense(50 => 4), x -> reshape(x, 2, 2))
         end
 
         aug_diffusion_sde = if nnlib == "Flux"
             Flux.Chain(
-                Flux.Dense(4 => 50, tanh), Flux.Dense(50 => 16), x -> reshape(x, 4, 4))
+                Flux.Dense(4 => 50, tanh), Flux.Dense(50 => 16), x -> reshape(x, 4, 4)
+            )
         else
             Chain(Dense(4 => 50, tanh), Dense(50 => 16), x -> reshape(x, 4, 4))
         end
 
         @testset "u0: $(typeof(u0)), solver: $(solver)" for u0 in (x,),
-            solver in (EulerHeun(), LambaEM())
+                solver in (EulerHeun(), LambaEM())
 
-            sode = NeuralSDE(dudt, diffusion_sde, tspan, 2, solver;
-                saveat = 0.0f0:0.01f0:0.1f0, dt = 0.01f0)
+            sode = NeuralSDE(
+                dudt, diffusion_sde, tspan, 2, solver;
+                saveat = 0.0f0:0.01f0:0.1f0, dt = 0.01f0
+            )
             pd, st = Lux.setup(rng, sode)
             pd = ComponentArray(pd)
 
@@ -167,8 +179,10 @@ end
             @test !iszero(grads[2])
             @test !iszero(grads[2][end])
 
-            sode = NeuralSDE(aug_dudt, aug_diffusion_sde, tspan, 4, solver;
-                saveat = 0.0f0:0.01f0:0.1f0, dt = 0.01f0)
+            sode = NeuralSDE(
+                aug_dudt, aug_diffusion_sde, tspan, 4, solver;
+                saveat = 0.0f0:0.01f0:0.1f0, dt = 0.01f0
+            )
             anode = AugmentedNDELayer(sode, 2)
             pd, st = Lux.setup(rng, anode)
             pd = ComponentArray(pd)
@@ -181,7 +195,7 @@ end
     end
 end
 
-@testitem "NeuralCDDE" tags=[:basicneuralde] begin
+@testitem "NeuralCDDE" tags = [:basicneuralde] begin
     using ComponentArrays, Zygote, DelayDiffEq, OrdinaryDiffEq, StochasticDiffEq, Random
     import Flux
 
@@ -206,8 +220,10 @@ end
         end
 
         @testset "NeuralCDDE u0: $(typeof(u0))" for u0 in (x, xs)
-            dode = NeuralCDDE(dudt, (0.0f0, 2.0f0), (u, p, t) -> zero(u), (0.1f0, 0.2f0),
-                MethodOfSteps(Tsit5()); saveat = 0.0f0:0.1f0:2.0f0)
+            dode = NeuralCDDE(
+                dudt, (0.0f0, 2.0f0), (u, p, t) -> zero(u), (0.1f0, 0.2f0),
+                MethodOfSteps(Tsit5()); saveat = 0.0f0:0.1f0:2.0f0
+            )
             pd, st = Lux.setup(rng, dode)
             pd = ComponentArray(pd)
 
@@ -217,7 +233,8 @@ end
 
             dode = NeuralCDDE(
                 aug_dudt, (0.0f0, 2.0f0), (u, p, t) -> zero(u), (0.1f0, 0.2f0),
-                MethodOfSteps(Tsit5()); saveat = 0.0f0:0.1f0:2.0f0)
+                MethodOfSteps(Tsit5()); saveat = 0.0f0:0.1f0:2.0f0
+            )
             anode = AugmentedNDELayer(dode, 2)
             pd, st = Lux.setup(rng, anode)
             pd = ComponentArray(pd)
@@ -229,7 +246,7 @@ end
     end
 end
 
-@testitem "DimMover" tags=[:basicneuralde] begin
+@testitem "DimMover" tags = [:basicneuralde] begin
     using Random
 
     rng = Xoshiro(0)
@@ -240,16 +257,16 @@ end
     @test first(layer(r, ps, st))[:, :, :, 1] == r[:, :, 1, :]
 end
 
-@testitem "Neural DE CUDA" tags=[:cuda] skip=:(using LuxCUDA; !LuxCUDA.functional()) begin
+@testitem "Neural DE CUDA" tags = [:cuda] skip = :(using LuxCUDA; !LuxCUDA.functional()) begin
     using LuxCUDA, Zygote, OrdinaryDiffEq, StochasticDiffEq, Test, Random, ComponentArrays
     import Flux
 
     CUDA.allowscalar(false)
 
-    rng=Xoshiro(0)
+    rng = Xoshiro(0)
 
-    const gdev=gpu_device()
-    const cdev=cpu_device()
+    const gdev = gpu_device()
+    const cdev = cpu_device()
 
     @testset "Neural DE" begin
         mp = Float32[0.1, 0.1] |> gdev
@@ -263,31 +280,37 @@ end
         @testset "Neural ODE" begin
             @testset "u0: $(typeof(u0))" for u0 in (x, xs)
                 @testset "kwargs: $(kwargs))" for kwargs in (
-                    (; save_everystep = false, save_start = false),
-                    (; save_everystep = false, save_start = false,
-                        sensealg = TrackerAdjoint()),
-                    (; save_everystep = false, save_start = false,
-                        sensealg = BacksolveAdjoint()),
-                    (; saveat = 0.0f0:0.1f0:1.0f0),
-                    (; saveat = 0.1f0),
-                    (; saveat = 0.0f0:0.1f0:1.0f0, sensealg = TrackerAdjoint()),
-                    (; saveat = 0.1f0, sensealg = TrackerAdjoint()))
+                        (; save_everystep = false, save_start = false),
+                        (;
+                            save_everystep = false, save_start = false,
+                            sensealg = TrackerAdjoint(),
+                        ),
+                        (;
+                            save_everystep = false, save_start = false,
+                            sensealg = BacksolveAdjoint(),
+                        ),
+                        (; saveat = 0.0f0:0.1f0:1.0f0),
+                        (; saveat = 0.1f0),
+                        (; saveat = 0.0f0:0.1f0:1.0f0, sensealg = TrackerAdjoint()),
+                        (; saveat = 0.1f0, sensealg = TrackerAdjoint()),
+                    )
                     node = NeuralODE(dudt, tspan, Tsit5(); kwargs...)
                     pd, st = Lux.setup(rng, node)
                     pd = ComponentArray(pd) |> gdev
                     st = st |> gdev
                     broken = hasfield(typeof(kwargs), :sensealg) &&
-                             ndims(u0) == 2 &&
-                             kwargs.sensealg isa TrackerAdjoint
+                        ndims(u0) == 2 &&
+                        kwargs.sensealg isa TrackerAdjoint
                     @test begin
                         grads = Zygote.gradient(sum ∘ last ∘ first ∘ node, u0, pd, st)
                         CUDA.@allowscalar begin
                             !iszero(grads[1]) && !iszero(grads[2])
                         end
-                    end broken=broken
+                    end broken = broken
 
                     anode = AugmentedNDELayer(
-                        NeuralODE(aug_dudt, tspan, Tsit5(); kwargs...), 2)
+                        NeuralODE(aug_dudt, tspan, Tsit5(); kwargs...), 2
+                    )
                     pd, st = Lux.setup(rng, anode)
                     pd = ComponentArray(pd) |> gdev
                     st = st |> gdev
@@ -296,7 +319,7 @@ end
                         CUDA.@allowscalar begin
                             !iszero(grads[1]) && !iszero(grads[2])
                         end
-                    end broken=broken
+                    end broken = broken
                 end
             end
         end
@@ -306,11 +329,12 @@ end
 
         tspan = (0.0f0, 0.1f0)
         @testset "NeuralDSDE u0: $(typeof(u0)), solver: $(solver)" for u0 in (xs,),
-            solver in (SOSRI(),)
+                solver in (SOSRI(),)
             # CuVector seems broken on CI but I can't reproduce the failure locally
 
             sode = NeuralDSDE(
-                dudt, diffusion, tspan, solver; saveat = 0.0f0:0.01f0:0.1f0, dt = 0.01f0)
+                dudt, diffusion, tspan, solver; saveat = 0.0f0:0.01f0:0.1f0, dt = 0.01f0
+            )
             pd, st = Lux.setup(rng, sode)
             pd = ComponentArray(pd) |> gdev
             st = st |> gdev

--- a/test/neural_ode_mm_tests.jl
+++ b/test/neural_ode_mm_tests.jl
@@ -1,4 +1,4 @@
-@testitem "Neural ODE Mass Matrix" tags=[:basicneuralde] begin
+@testitem "Neural ODE Mass Matrix" tags = [:basicneuralde] begin
     using ComponentArrays, Zygote, Random, Optimization, OptimizationOptimJL, OrdinaryDiffEq
 
     rng = Xoshiro(0)
@@ -13,11 +13,13 @@
         nothing
     end
     u₀ = [1.0, 0, 0]
-    M = [1.0 0 0
-         0 1.0 0
-         0 0 0]
+    M = [
+        1.0 0 0
+        0 1.0 0
+        0 0 0
+    ]
     tspan = (0.0, 1.0)
-    p = [0.04, 3e7, 1e4]
+    p = [0.04, 3.0e7, 1.0e4]
     func = ODEFunction(f; mass_matrix = M)
     prob = ODEProblem(func, u₀, tspan, p)
     sol = solve(prob, Rodas5(); saveat = 0.1)
@@ -25,8 +27,10 @@
     dudt2 = Chain(Dense(3 => 64, tanh), Dense(64 => 2))
     p, st = Lux.setup(rng, dudt2)
     p = ComponentArray{Float64}(p)
-    ndae = NeuralODEMM(dudt2, (u, p, t) -> [u[1] + u[2] + u[3] - 1],
-        tspan, M, Rodas5(; autodiff = false); saveat = 0.1)
+    ndae = NeuralODEMM(
+        dudt2, (u, p, t) -> [u[1] + u[2] + u[3] - 1],
+        tspan, M, Rodas5(; autodiff = false); saveat = 0.1
+    )
     ndae(u₀, p, st)
 
     function loss(p)
@@ -42,9 +46,11 @@
 
     l1 = first(loss(p))
     optfunc = Optimization.OptimizationFunction(
-        (x, p) -> loss(x), Optimization.AutoZygote())
+        (x, p) -> loss(x), Optimization.AutoZygote()
+    )
     optprob = Optimization.OptimizationProblem(optfunc, p)
     res = Optimization.solve(
-        optprob, BFGS(; initial_stepnorm = 0.001); callback = cb, maxiters = 100)
+        optprob, BFGS(; initial_stepnorm = 0.001); callback = cb, maxiters = 100
+    )
     @test res.minimum < l1
 end

--- a/test/newton_neural_ode_tests.jl
+++ b/test/newton_neural_ode_tests.jl
@@ -1,4 +1,4 @@
-@testitem "Newton Neural ODE" tags=[:newton] begin
+@testitem "Newton Neural ODE" tags = [:newton] begin
     using ComponentArrays, Zygote, Optimization, OptimizationOptimJL, OrdinaryDiffEq, Random
 
     Random.seed!(100)
@@ -30,13 +30,16 @@
     loss_function(θ) = sum(abs2, y .- stnODE(x, ComponentArray(θ, psax))[end])
     l1 = loss_function(psd)
     optf = Optimization.OptimizationFunction(
-        (x, p) -> loss_function(x), Optimization.AutoZygote())
+        (x, p) -> loss_function(x), Optimization.AutoZygote()
+    )
     optprob = Optimization.OptimizationProblem(optf, psd)
 
     res = Optimization.solve(optprob, NewtonTrustRegion(); maxiters = 100, callback = cb)
     @test loss_function(res.minimizer) < l1
-    res = Optimization.solve(optprob, OptimizationOptimJL.Optim.KrylovTrustRegion();
-        maxiters = 100, callback = cb)
+    res = Optimization.solve(
+        optprob, OptimizationOptimJL.Optim.KrylovTrustRegion();
+        maxiters = 100, callback = cb
+    )
     @test loss_function(res.minimizer) < l1
 
     @info "ROCK2"
@@ -51,12 +54,15 @@
     loss_function(θ) = sum(abs2, y .- stnODE(x, ComponentArray(θ, psax))[end])
     l1 = loss_function(psd)
     optfunc = Optimization.OptimizationFunction(
-        (x, p) -> loss_function(x), Optimization.AutoZygote())
+        (x, p) -> loss_function(x), Optimization.AutoZygote()
+    )
     optprob = Optimization.OptimizationProblem(optfunc, psd)
 
     res = Optimization.solve(optprob, NewtonTrustRegion(); maxiters = 100, callback = cb)
     @test loss_function(res.minimizer) < l1
-    res = Optimization.solve(optprob, OptimizationOptimJL.Optim.KrylovTrustRegion();
-        maxiters = 100, callback = cb)
+    res = Optimization.solve(
+        optprob, OptimizationOptimJL.Optim.KrylovTrustRegion();
+        maxiters = 100, callback = cb
+    )
     @test loss_function(res.minimizer) < l1
 end

--- a/test/qa_tests.jl
+++ b/test/qa_tests.jl
@@ -1,14 +1,15 @@
-@testitem "Aqua Q/A" tags=[:qa] begin
+@testitem "Aqua Q/A" tags = [:qa] begin
     using Aqua
 
     Aqua.test_all(DiffEqFlux; ambiguities = false)
     Aqua.test_ambiguities(DiffEqFlux; recursive = false)
 end
 
-@testitem "Explicit Imports" tags=[:qa] begin
+@testitem "Explicit Imports" tags = [:qa] begin
     using ExplicitImports
 
     @test check_no_implicit_imports(
-        DiffEqFlux; skip = (ADTypes, Lux, Base, Boltz, Core)) === nothing
+        DiffEqFlux; skip = (ADTypes, Lux, Base, Boltz, Core)
+    ) === nothing
     @test check_no_stale_explicit_imports(DiffEqFlux) === nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,13 +6,20 @@ using DiffEqFlux
 const GROUP = lowercase(get(ENV, "GROUP", "all"))
 
 const RETESTITEMS_NWORKERS = parse(
-    Int, get(ENV, "RETESTITEMS_NWORKERS", string(min(Hwloc.num_physical_cores(), 16))))
-const RETESTITEMS_NWORKER_THREADS = parse(Int,
-    get(ENV, "RETESTITEMS_NWORKER_THREADS",
-        string(max(Hwloc.num_virtual_cores() ÷ RETESTITEMS_NWORKERS, 1))))
+    Int, get(ENV, "RETESTITEMS_NWORKERS", string(min(Hwloc.num_physical_cores(), 16)))
+)
+const RETESTITEMS_NWORKER_THREADS = parse(
+    Int,
+    get(
+        ENV, "RETESTITEMS_NWORKER_THREADS",
+        string(max(Hwloc.num_virtual_cores() ÷ RETESTITEMS_NWORKERS, 1))
+    )
+)
 
 @info "Running tests for group: $GROUP with $RETESTITEMS_NWORKERS workers"
 
-ReTestItems.runtests(DiffEqFlux; tags = (GROUP == "all" ? nothing : [Symbol(GROUP)]),
+ReTestItems.runtests(
+    DiffEqFlux; tags = (GROUP == "all" ? nothing : [Symbol(GROUP)]),
     nworkers = RETESTITEMS_NWORKERS,
-    nworker_threads = RETESTITEMS_NWORKER_THREADS, testitem_timeout = 3600)
+    nworker_threads = RETESTITEMS_NWORKER_THREADS, testitem_timeout = 3600
+)

--- a/test/second_order_ode_tests.jl
+++ b/test/second_order_ode_tests.jl
@@ -1,6 +1,6 @@
-@testitem "Second Order Neural ODE" tags=[:advancedneuralde] begin
+@testitem "Second Order Neural ODE" tags = [:advancedneuralde] begin
     using ComponentArrays, Zygote, Random, Optimization, OptimizationOptimisers,
-          OrdinaryDiffEq
+        OrdinaryDiffEq
 
     rng = Xoshiro(0)
 
@@ -16,12 +16,21 @@
     prob = SecondOrderODEProblem{false}(ff, du0, u0, tspan, p)
 
     function predict(p)
-        return Array(solve(prob, Tsit5(); p, saveat = t,
-            sensealg = InterpolatingAdjoint(; autojacvec = ZygoteVJP())))
+        return Array(
+            solve(
+                prob, Tsit5(); p, saveat = t,
+                sensealg = InterpolatingAdjoint(; autojacvec = ZygoteVJP())
+            )
+        )
     end
 
-    correct_pos = Float32.(transpose(hcat(
-        collect(0:0.05:1)[2:end], collect(2:-0.05:1)[2:end])))
+    correct_pos = Float32.(
+        transpose(
+            hcat(
+                collect(0:0.05:1)[2:end], collect(2:-0.05:1)[2:end]
+            )
+        )
+    )
 
     function loss_n_ode(p)
         pred = predict(p)
@@ -36,19 +45,29 @@
     end
 
     optfunc = Optimization.OptimizationFunction(
-        (x, p) -> loss_n_ode(x), Optimization.AutoZygote())
+        (x, p) -> loss_n_ode(x), Optimization.AutoZygote()
+    )
     optprob = Optimization.OptimizationProblem(optfunc, p)
     res = Optimization.solve(optprob, Adam(0.01f0); callback = callback, maxiters = 100)
     l2 = loss_n_ode(res.minimizer)
     @test l2 < l1
 
     function predict(p)
-        return Array(solve(prob, Tsit5(); p, saveat = t,
-            sensealg = QuadratureAdjoint(; autojacvec = ZygoteVJP())))
+        return Array(
+            solve(
+                prob, Tsit5(); p, saveat = t,
+                sensealg = QuadratureAdjoint(; autojacvec = ZygoteVJP())
+            )
+        )
     end
 
-    correct_pos = Float32.(transpose(hcat(
-        collect(0:0.05:1)[2:end], collect(2:-0.05:1)[2:end])))
+    correct_pos = Float32.(
+        transpose(
+            hcat(
+                collect(0:0.05:1)[2:end], collect(2:-0.05:1)[2:end]
+            )
+        )
+    )
 
     function loss_n_ode(p)
         pred = predict(p)
@@ -56,19 +75,29 @@
     end
 
     optfunc = Optimization.OptimizationFunction(
-        (x, p) -> loss_n_ode(x), Optimization.AutoZygote())
+        (x, p) -> loss_n_ode(x), Optimization.AutoZygote()
+    )
     optprob = Optimization.OptimizationProblem(optfunc, p)
     res = Optimization.solve(optprob, Adam(0.01f0); callback = callback, maxiters = 100)
     l2 = loss_n_ode(res.minimizer)
     @test l2 < l1
 
     function predict(p)
-        return Array(solve(prob, Tsit5(); p, saveat = t,
-            sensealg = BacksolveAdjoint(; autojacvec = ZygoteVJP())))
+        return Array(
+            solve(
+                prob, Tsit5(); p, saveat = t,
+                sensealg = BacksolveAdjoint(; autojacvec = ZygoteVJP())
+            )
+        )
     end
 
-    correct_pos = Float32.(transpose(hcat(
-        collect(0:0.05:1)[2:end], collect(2:-0.05:1)[2:end])))
+    correct_pos = Float32.(
+        transpose(
+            hcat(
+                collect(0:0.05:1)[2:end], collect(2:-0.05:1)[2:end]
+            )
+        )
+    )
 
     function loss_n_ode(p)
         pred = predict(p)
@@ -76,7 +105,8 @@
     end
 
     optfunc = Optimization.OptimizationFunction(
-        (x, p) -> loss_n_ode(x), Optimization.AutoZygote())
+        (x, p) -> loss_n_ode(x), Optimization.AutoZygote()
+    )
     optprob = Optimization.OptimizationProblem(optfunc, p)
     res = Optimization.solve(optprob, Adam(0.01f0); callback = callback, maxiters = 100)
     l2 = loss_n_ode(res.minimizer)

--- a/test/stiff_nested_ad_tests.jl
+++ b/test/stiff_nested_ad_tests.jl
@@ -1,6 +1,6 @@
-@testitem "Stiff Nested AD" tags=[:layers] begin
+@testitem "Stiff Nested AD" tags = [:layers] begin
     using ComponentArrays, Zygote, OrdinaryDiffEq, Optimization, OptimizationOptimisers,
-          Random
+        Random
 
     u0 = [2.0; 0.0]
     datasize = 30
@@ -28,17 +28,20 @@
     end
 
     @testset "Solver: $(nameof(typeof(solver)))" for solver in (
-        KenCarp4(), Rodas5(), RadauIIA5())
-        neuralde = NeuralODE(model, tspan, solver; saveat = t, reltol = 1e-7, abstol = 1e-9)
+            KenCarp4(), Rodas5(), RadauIIA5(),
+        )
+        neuralde = NeuralODE(model, tspan, solver; saveat = t, reltol = 1.0e-7, abstol = 1.0e-9)
         ps, st = Lux.setup(Xoshiro(0), neuralde)
         ps = ComponentArray(ps)
         lux_model = StatefulLuxLayer{true}(neuralde, ps, st)
         loss1 = loss_n_ode(lux_model, ps)
         optfunc = Optimization.OptimizationFunction(
-            (x, p) -> loss_n_ode(lux_model, x), Optimization.AutoZygote())
+            (x, p) -> loss_n_ode(lux_model, x), Optimization.AutoZygote()
+        )
         optprob = Optimization.OptimizationProblem(optfunc, ps)
         res = Optimization.solve(
-            optprob, Adam(0.1); callback = callback(solver), maxiters = 100)
+            optprob, Adam(0.1); callback = callback(solver), maxiters = 100
+        )
         loss2 = loss_n_ode(lux_model, res.minimizer)
         @test loss2 < loss1
     end


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)