### PR TITLE
Add Local Regularization Support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,9 +23,11 @@ Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 
 [weakdeps]
 DataInterpolations = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
+OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 
 [extensions]
 DiffEqFluxDataInterpolationsExt = "DataInterpolations"
+DiffEqFluxOrdinaryDiffEqTsit5Ext = "OrdinaryDiffEqTsit5"
 
 [compat]
 ADTypes = "1.21"
@@ -60,6 +62,7 @@ OrdinaryDiffEqFIRK = "2"
 OrdinaryDiffEqRosenbrock = "2"
 OrdinaryDiffEqSDIRK = "2"
 OrdinaryDiffEqStabilizedRK = "2"
+OrdinaryDiffEqTsit5 = "2"
 PrecompileTools = "1.2.1"
 Printf = "1.10"
 Random = "1.10"
@@ -100,6 +103,7 @@ OrdinaryDiffEqFIRK = "5960d6e9-dd7a-4743-88e7-cf307b64f125"
 OrdinaryDiffEqRosenbrock = "43230ef6-c299-4910-a778-202eb28ce4ce"
 OrdinaryDiffEqSDIRK = "2d112036-d095-4a1e-ab9a-08536f3ecdbf"
 OrdinaryDiffEqStabilizedRK = "358294b1-0aab-51c3-aafe-ad5ab194a2ad"
+OrdinaryDiffEqTsit5 = "b1df2697-797e-41e3-8120-5422d3b24e4a"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
@@ -111,4 +115,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
-test = ["Aqua", "BenchmarkTools", "ComponentArrays", "DataInterpolations", "DelayDiffEq", "DiffEqCallbacks", "Distances", "Distributed", "DistributionsAD", "ForwardDiff", "Flux", "NNlib", "OneHotArrays", "Optimisers", "Optimization", "OptimizationOptimJL", "OptimizationOptimisers", "OrdinaryDiffEq", "OrdinaryDiffEqBDF", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqStabilizedRK", "Printf", "Random", "Reexport", "SafeTestsets", "SciMLTesting", "Statistics", "StochasticDiffEq", "Test", "Zygote"]
+test = ["Aqua", "BenchmarkTools", "ComponentArrays", "DataInterpolations", "DelayDiffEq", "DiffEqCallbacks", "Distances", "Distributed", "DistributionsAD", "ForwardDiff", "Flux", "NNlib", "OneHotArrays", "Optimisers", "Optimization", "OptimizationOptimJL", "OptimizationOptimisers", "OrdinaryDiffEq", "OrdinaryDiffEqBDF", "OrdinaryDiffEqFIRK", "OrdinaryDiffEqRosenbrock", "OrdinaryDiffEqSDIRK", "OrdinaryDiffEqStabilizedRK", "OrdinaryDiffEqTsit5", "Printf", "Random", "Reexport", "SafeTestsets", "SciMLTesting", "Statistics", "StochasticDiffEq", "Test", "Zygote"]

--- a/ext/DiffEqFluxOrdinaryDiffEqTsit5Ext.jl
+++ b/ext/DiffEqFluxOrdinaryDiffEqTsit5Ext.jl
@@ -1,0 +1,19 @@
+module DiffEqFluxOrdinaryDiffEqTsit5Ext
+
+using DiffEqFlux: DiffEqFlux
+using OrdinaryDiffEqTsit5: Tsit5ConstantCache
+import OrdinaryDiffEqTsit5
+
+function DiffEqFlux.local_regularization_step(
+        integrator, cache::Tsit5ConstantCache, p
+    )
+    step_data = OrdinaryDiffEqTsit5.perform_step(integrator, cache, p)
+    residuals = step_data.utilde ./ (
+        integrator.opts.abstol .+
+        max.(abs.(integrator.uprev), abs.(step_data.u)) .* integrator.opts.reltol
+    )
+    reg_val = sqrt(sum(abs2, residuals) / length(step_data.u)) * step_data.dt
+    return reg_val, step_data.nf + DiffEqFlux.__ode_nfe(integrator.sol)
+end
+
+end

--- a/ext/DiffEqFluxOrdinaryDiffEqTsit5Ext.jl
+++ b/ext/DiffEqFluxOrdinaryDiffEqTsit5Ext.jl
@@ -1,19 +1,13 @@
 module DiffEqFluxOrdinaryDiffEqTsit5Ext
 
-using DiffEqFlux: DiffEqFlux
-using OrdinaryDiffEqTsit5: Tsit5ConstantCache
-import OrdinaryDiffEqTsit5
+import DiffEqFlux: local_regularization_step
+using SciMLBase: DEIntegrator
+import OrdinaryDiffEqTsit5: Tsit5, perform_step
 
-function DiffEqFlux.local_regularization_step(
-        integrator, cache::Tsit5ConstantCache, p
-    )
-    step_data = OrdinaryDiffEqTsit5.perform_step(integrator, cache, p)
-    residuals = step_data.utilde ./ (
-        integrator.opts.abstol .+
-        max.(abs.(integrator.uprev), abs.(step_data.u)) .* integrator.opts.reltol
-    )
-    reg_val = sqrt(sum(abs2, residuals) / length(step_data.u)) * step_data.dt
-    return reg_val, step_data.nf + DiffEqFlux.__ode_nfe(integrator.sol)
+function local_regularization_step(integrator::DEIntegrator{Alg}, p) where {Alg <: Tsit5}
+    _, reg_val, local_nf, _ = perform_step(integrator, p)
+    reg_val, local_nf
 end
 
 end
+

--- a/ext/DiffEqFluxOrdinaryDiffEqTsit5Ext.jl
+++ b/ext/DiffEqFluxOrdinaryDiffEqTsit5Ext.jl
@@ -1,0 +1,95 @@
+module DiffEqFluxOrdinaryDiffEqTsit5Ext
+
+import DiffEqFlux: error_estimate_regularization
+import ChainRulesCore as CRC
+using SciMLBase: DEIntegrator, step!
+import SciMLBase
+import OrdinaryDiffEqTsit5
+import OrdinaryDiffEqTsit5: Tsit5
+
+function _tsit5_error_estimate_regularization(
+        k1, uprev, model, p, t, dt, abstol, reltol
+    )
+    tab = OrdinaryDiffEqTsit5.Tsit5ConstantCacheActual(eltype(uprev), typeof(one(t)))
+    (;
+        c1, c2, c3, c4, a21, a31, a32, a41, a42, a43, a51, a52, a53, a54,
+        a61, a62, a63, a64, a65, a71, a72, a73, a74, a75, a76,
+        btilde1, btilde2, btilde3, btilde4, btilde5, btilde6, btilde7,
+    ) = tab
+
+    k2 = model(((@. uprev + dt * a21 * k1), t + c1 * dt), p)
+    k3 = model(
+        ((@. uprev + dt * (a31 * k1 + a32 * k2)), t + c2 * dt), p
+    )
+    k4 = model(
+        ((@. uprev + dt * (a41 * k1 + a42 * k2 + a43 * k3)), t + c3 * dt), p
+    )
+    k5 = model(
+        ((@. uprev + dt * (a51 * k1 + a52 * k2 + a53 * k3 + a54 * k4)),
+            t + c4 * dt),
+        p,
+    )
+    g6 = @. uprev + dt * (a61 * k1 + a62 * k2 + a63 * k3 + a64 * k4 + a65 * k5)
+    k6 = model((g6, t + dt), p)
+    unew = @. uprev +
+        dt * (a71 * k1 + a72 * k2 + a73 * k3 + a74 * k4 + a75 * k5 + a76 * k6)
+    k7 = model((unew, t + dt), p)
+    utilde = @. dt * (
+        btilde1 * k1 + btilde2 * k2 + btilde3 * k3 + btilde4 * k4 +
+            btilde5 * k5 + btilde6 * k6 + btilde7 * k7
+    )
+    residuals = @. utilde / (abstol + max(abs(uprev), abs(unew)) * reltol)
+    return sqrt(sum(abs2, residuals) / length(unew)) * abs(dt)
+end
+
+function error_estimate_regularization(integrator::DEIntegrator{Alg}, model, p) where {Alg <: Tsit5}
+    nf0 = CRC.@ignore_derivatives integrator.stats.nf
+    integrator.p = p
+    step!(integrator)
+    reg_val = integrator.EEst * abs(integrator.t - integrator.tprev)
+    local_nf = CRC.@ignore_derivatives integrator.stats.nf - nf0
+    return reg_val, local_nf
+end
+
+function _tsit5_pullback_data(integrator)
+    return CRC.@ignore_derivatives begin
+        k1 = integrator.fsalfirst
+        uprev = integrator.uprev
+        (
+            copy(k1),
+            copy(uprev),
+            integrator.t,
+            integrator.dt,
+            integrator.opts.abstol,
+            integrator.opts.reltol,
+        )
+    end
+end
+
+function CRC.rrule(
+        config::CRC.RuleConfig{>:CRC.HasReverseMode},
+        ::typeof(error_estimate_regularization),
+        integrator::DEIntegrator{Alg},
+        model,
+        p
+    ) where {Alg <: Tsit5}
+    pullback_data = _tsit5_pullback_data(integrator)
+    y = error_estimate_regularization(integrator, model, p)
+
+    function error_estimate_regularization_pullback(Delta)
+        k1, uprev, t, dt, abstol, reltol = pullback_data
+        _, back = CRC.rrule_via_ad(
+            config,
+            p -> _tsit5_error_estimate_regularization(
+                k1, uprev, model, p, t, dt, abstol, reltol
+            ),
+            p,
+        )
+        d = back(first(Delta))
+        dp = d[2]
+        return CRC.NoTangent(), CRC.NoTangent(), CRC.NoTangent(), dp
+    end
+    return y, error_estimate_regularization_pullback
+end
+
+end

--- a/src/DiffEqFlux.jl
+++ b/src/DiffEqFlux.jl
@@ -60,3 +60,4 @@ export TrackerVJP, ZygoteVJP, EnzymeVJP, ReverseDiffVJP
 include("precompilation.jl")
 
 end
+

--- a/src/DiffEqFlux.jl
+++ b/src/DiffEqFlux.jl
@@ -32,6 +32,7 @@ fixed_state_type(::Layers.HamiltonianNN{False}) = false
 
 include("ffjord.jl")
 include("neural_de.jl")
+include("neural_de_regularization.jl")
 
 include("collocation.jl")
 include("multiple_shooting.jl")

--- a/src/DiffEqFlux.jl
+++ b/src/DiffEqFlux.jl
@@ -33,6 +33,7 @@ fixed_state_type(::Layers.HamiltonianNN{False}) = false
 
 include("ffjord.jl")
 include("neural_de.jl")
+include("neural_de_regularization.jl")
 
 include("collocation.jl")
 include("multiple_shooting.jl")

--- a/src/neural_de.jl
+++ b/src/neural_de.jl
@@ -39,9 +39,13 @@ References:
     kwargs
 end
 
-function NeuralODE(model, tspan, args...; kwargs...)
+function NeuralODE(
+        model, tspan, args...;
+        regularize = nothing,
+        kwargs...
+    )
     !(model isa AbstractLuxLayer) && (model = FromFluxAdaptor()(model))
-    return NeuralODE(model, tspan, args, kwargs)
+    return __construct_neural_ode(model, tspan, args, regularize, kwargs)
 end
 
 function (n::NeuralODE)(x, p, st)

--- a/src/neural_de.jl
+++ b/src/neural_de.jl
@@ -45,15 +45,23 @@ function NeuralODE(
         kwargs...
     )
     !(model isa AbstractLuxLayer) && (model = FromFluxAdaptor()(model))
-    return __construct_neural_ode(model, tspan, args, regularize, kwargs)
+    regularize === nothing && return NeuralODE(model, tspan, args, kwargs)
+    if regularize isa Bool
+        regularize = regularize ? :unbiased : :none
+    end
+    return RegularizedNeuralODE{regularize}(model, tspan, args, values(kwargs))
 end
 
 function (n::NeuralODE)(x, p, st)
     model = StatefulLuxLayer{fixed_state_type(n.model)}(n.model, nothing, st)
 
     dudt(u, p, t) = model(u, p)
-    ff = ODEFunction{false}(dudt; tgrad = basic_tgrad)
-    prob = ODEProblem{false}(ff, x, n.tspan, p)
+    function dudt!(du, u, p, t)
+        copyto!(du, dudt(u, p, t))
+        return nothing
+    end
+    ff = ODEFunction{true}(dudt!)
+    prob = ODEProblem{true}(ff, x, n.tspan, p)
 
     return (
         solve(
@@ -414,3 +422,4 @@ function (dm::DimMover)(x, ps, st)
 
     return cat(eachslice(x; dims = from)...; dims = to), st
 end
+

--- a/src/neural_de.jl
+++ b/src/neural_de.jl
@@ -39,9 +39,14 @@ References:
     kwargs
 end
 
-function NeuralODE(model, tspan, args...; kwargs...)
+function NeuralODE(
+        model, tspan, args...;
+        regularize = nothing,
+        kwargs...
+    )
     !(model isa AbstractLuxLayer) && (model = FromFluxAdaptor()(model))
-    return NeuralODE(model, tspan, args, kwargs)
+    regularize === nothing && return NeuralODE(model, tspan, args, kwargs)
+    return regularized_neuralode(model, tspan, regularize, args, values(kwargs))
 end
 
 function (n::NeuralODE)(x, p, st)

--- a/src/neural_de_regularization.jl
+++ b/src/neural_de_regularization.jl
@@ -1,47 +1,47 @@
-struct ArrayAndTime{A, T <: Real}
+struct ArrayAndTime{A <: AbstractArray, T <: Real}
     array::A
     scalar::T
 end
 
 function Lux.apply(l::AbstractLuxLayer, x::ArrayAndTime, ps, st::NamedTuple)
     y, st_ = Lux.apply(l, x.array, ps, st)
-    return ArrayAndTime(y, x.scalar), st_
+    ArrayAndTime(y, x.scalar), st_
 end
 
 struct TDChain{L <: NamedTuple} <: AbstractLuxWrapperLayer{:layers}
     layers::L
 
-    TDChain(c::Chain) = new{typeof(c.layers)}(c.layers)
-    TDChain(; kwargs...) = new{typeof((; kwargs...))}((; kwargs...))
+    TDChain(c::Chain) = TDChain(c.layers)
+    TDChain(; kwargs...) = TDChain((; kwargs...))
     TDChain(layers::NamedTuple) = new{typeof(layers)}(layers)
 end
 
-function _time_channel_like(x::AbstractArray, t, dims)
-    return fill!(similar(x, eltype(x), dims), convert(eltype(x), t))
-end
+(c::TDChain)((x, t), ps, st::NamedTuple) = applytdchain(c.layers, x, t, ps, st)
 
-CRC.@non_differentiable _time_channel_like(::Any...)
-
-function (c::TDChain)((x, t), ps, st::NamedTuple)
-    return applytdchain(c.layers, x, t, ps, st)
-end
-
-@generated function applytdchain(layers::NamedTuple{fields}, x::T, t, ps, st) where {fields, T}
+@generated function applytdchain(
+        layers::NamedTuple{fields}, x::T, t, ps, st::NamedTuple{fields}
+    ) where {fields, T}
     N = length(fields)
     cat_dim = max(ndims(T) - 1, 1)
-    x_symbols = [:x; [gensym(:x) for _ in 1:N]]
-    st_symbols = [gensym(:st) for _ in 1:N]
-    dims = Expr(:tuple, [i == cat_dim ? 1 : :(size(x, $i)) for i in 1:(ndims(T))]...)
-    block = Any[:(_t = _time_channel_like(x, t, $dims))]
+    x_symbols = vcat([:x], [gensym("x") for _ in 1:N])
+    st_symbols = [gensym("st") for _ in 1:N]
+    calls = [
+        :(
+            _t = fill!(
+                similar(x, eltype(x), ntuple(i -> i == $cat_dim ? 1 : size(x, i), ndims(x))),
+                convert(eltype(x), t),
+            )
+        ),
+    ]
 
     for i in 1:N
         field = fields[i]
         push!(
-            block,
+            calls,
             :(
                 ($(x_symbols[i + 1]), $(st_symbols[i])) = Lux.apply(
                     layers.$field,
-                    cat($(x_symbols[i]), _t; dims = Val($cat_dim)),
+                    cat($(x_symbols[i]), _t; dims = $cat_dim),
                     ps.$field,
                     st.$field,
                 )
@@ -50,32 +50,24 @@ end
     end
 
     st_out = Expr(:tuple, st_symbols...)
-    push!(block, :(return ($(x_symbols[N + 1]), _t), NamedTuple{$fields}($st_out)))
-    return Expr(:block, block...)
+    push!(
+        calls,
+        :(return ($(x_symbols[N + 1]), _t), NamedTuple{$fields}($st_out)),
+    )
+    return Expr(:block, calls...)
 end
 
 function Lux.apply(l::TDChain, x::ArrayAndTime, ps, st::NamedTuple)
     (y, _), st_ = Lux.apply(l, (x.array, x.scalar), ps, st)
-    return ArrayAndTime(y, x.scalar), st_
+    ArrayAndTime(y, x.scalar), st_
 end
 
-@concrete struct RegularizedNeuralODE <: NeuralDELayer
+@concrete struct RegularizedNeuralODE{R} <: NeuralDELayer
     model <: AbstractLuxLayer
     tspan
     args
-    regularize::Symbol
     kwargs
 end
-
-    function __construct_neural_ode(model, tspan, args, regularize, kwargs)
-        regularize === nothing && return NeuralODE(model, tspan, args, kwargs)
-        if regularize isa Bool
-        regularize = regularize ? :unbiased : :none
-        end
-        regularize in (:none, :unbiased, :biased) ||
-            throw(ArgumentError("`regularize` must be one of `:none`, `:unbiased`, or `:biased`."))
-        return RegularizedNeuralODE(model, tspan, args, regularize, values(kwargs))
-    end
 
 LuxCore.initialstates(rng::AbstractRNG, n::RegularizedNeuralODE) = (;
     model = LuxCore.initialstates(rng, n.model),
@@ -85,151 +77,204 @@ LuxCore.initialstates(rng::AbstractRNG, n::RegularizedNeuralODE) = (;
     training = Val(true),
 )
 
-function __ode_nfe(sol)
-    if hasproperty(sol, :destats) && hasproperty(sol.destats, :nf)
-        return sol.destats.nf
-    elseif hasproperty(sol, :stats) && hasproperty(sol.stats, :nf)
-        return sol.stats.nf
-    else
-        return -1
-    end
+mutable struct ReservoirState{R, T, U}
+    rng::R
+    count::Int
+    pending_t::Union{Nothing, T}
+    pending_u::Union{Nothing, U}
+    treg::Union{Nothing, T}
+    ureg::Union{Nothing, U}
 end
 
-CRC.@non_differentiable __ode_nfe(::Any...)
+function ReservoirState(rng, t::T, u::U, save_start::Bool) where {T, U}
+    pending_t = save_start ? t : nothing
+    pending_u = if save_start
+        u isa Number ? u : copyto!(similar(u), u)
+    else
+        nothing
+    end
+    ReservoirState{typeof(rng), T, U}(rng, 0, pending_t, pending_u, nothing, nothing)
+end
 
-function __regularized_solve(
-        n::RegularizedNeuralODE, x, p, st; kwargs = n.kwargs
+struct ReservoirCallback{S}
+    state::S
+end
+
+function update_reservoir!(state::ReservoirState, t, u)
+    if state.pending_t !== nothing
+        state.count += 1
+        if state.count == 1 || rand(state.rng, 1:state.count) == 1
+            state.treg = state.pending_t
+            pending_u = state.pending_u
+            state.ureg = if pending_u isa Number
+                pending_u
+            elseif state.ureg === nothing
+                copyto!(similar(pending_u), pending_u)
+            else
+                copyto!(state.ureg, pending_u)
+            end
+        end
+    end
+
+    state.pending_t = t
+    state.pending_u = if u isa Number
+        u
+    elseif state.pending_u === nothing
+        copyto!(similar(u), u)
+    else
+        copyto!(state.pending_u, u)
+    end
+    return nothing
+end
+
+function (affect::ReservoirCallback)(integrator)
+    update_reservoir!(affect.state, integrator.t, integrator.u)
+    SciMLBase.u_modified!(integrator, false)
+    nothing
+end
+
+function reservoir_callback(state::ReservoirState)
+    SciMLBase.DiscreteCallback(
+        (u, t, integrator) -> integrator.iter > 0,
+        ReservoirCallback(state);
+        save_positions = (false, false),
     )
-    model_state = hasproperty(st, :model) ? st.model : st
-    model = StatefulLuxLayer{fixed_state_type(n.model)}(
-        n.model, nothing, model_state
+end
+
+function SciMLSensitivity._track_callback(
+        cb::SciMLBase.DiscreteCallback{C, A}, t, u, p, sensealg
+    ) where {C, A <: ReservoirCallback}
+    cb
+end
+
+function SciMLSensitivity._setup_reverse_callbacks(
+        cb::SciMLBase.DiscreteCallback{C, A},
+        affect::A, sensealg, dgdu,
+        dgdp,
+        loss_ref, terminated
+    ) where {C, A <: ReservoirCallback}
+    SciMLBase.DiscreteCallback(
+        (u, t, integrator) -> false,
+        integrator -> nothing;
+        save_positions = (false, false),
     )
+end
+
+CRC.@non_differentiable update_reservoir!(::Any...)
+CRC.@non_differentiable reservoir_callback(::Any...)
+
+function solve_node(n::RegularizedNeuralODE, x, p, st, kwargs)
+    model = StatefulLuxLayer{fixed_state_type(n.model)}(n.model, nothing, st.model)
 
     dudt(u, p, t) = model(ArrayAndTime(u, t), p).array
-    ff = ODEFunction{false}(dudt; tgrad = basic_tgrad)
-    prob = ODEProblem{false}(ff, x, n.tspan, p)
+    function dudt!(du, u, p, t)
+        copyto!(du, dudt(u, p, t))
+        return nothing
+    end
+
+    prob = ODEProblem{true}(ODEFunction{true}(dudt!), x, n.tspan, p)
+    local_prob = ODEProblem{false}(ODEFunction{false}(dudt; tgrad = basic_tgrad), x, n.tspan, p)
     sol = solve(
         prob, n.args...;
         sensealg = InterpolatingAdjoint(; autojacvec = ZygoteVJP()), kwargs...
     )
-    return sol, model.st, prob
+    sol, model.st, local_prob
 end
 
-function local_regularization_step(integrator, cache, p)
-    throw(
-        ArgumentError(
-            "Local regularization is not implemented for solver $(typeof(integrator.alg)) " *
-            "with cache $(typeof(cache))."
-        ),
-    )
+function local_regularization_step end
+
+function vanilla_node(n::RegularizedNeuralODE, x, p, st)
+    solve_kwargs = haskey(n.kwargs, :saveat) ?
+        n.kwargs :
+        merge(n.kwargs, (; saveat = [last(n.tspan)]))
+    sol, model_st, _ = solve_node(n, x, p, st, solve_kwargs)
+    sol, (; model = model_st, nfe = sol.destats.nf, reg_val = 0.0f0, st.rng, st.training)
 end
 
-function __vanilla_regularized_neural_ode(n::RegularizedNeuralODE, x, p, st)
-    solve_kwargs = let kws = n.kwargs
-        haskey(kws, :saveat) ? kws : merge(kws, (; saveat = [last(n.tspan)]))
+function biased_node(n::RegularizedNeuralODE, x, p, st)
+    rng = Lux.replicate(st.rng)
+    kws = n.kwargs
+    save_start = get(kws, :save_start, true)
+    reservoir = CRC.@ignore_derivatives ReservoirState(rng, first(n.tspan), x, save_start)
+    solve_kwargs = CRC.@ignore_derivatives begin
+        callback = reservoir_callback(reservoir)
+        solve_kwargs = haskey(kws, :callback) ?
+            merge(kws, (; callback = SciMLBase.CallbackSet(kws[:callback], callback))) :
+            merge(kws, (; callback))
+        if !haskey(kws, :saveat) && !haskey(kws, :save_everystep)
+            solve_kwargs = merge(solve_kwargs, (; save_everystep = false, save_end = true))
+        end
+        solve_kwargs
     end
-    sol, model_st, _ = __regularized_solve(
-        n, x, p, st; kwargs = solve_kwargs
-    )
-    nfe = __ode_nfe(sol)
-    rng = hasproperty(st, :rng) ? st.rng : Random.default_rng()
-    training = hasproperty(st, :training) ? st.training : Val(true)
-    return sol, (; model = model_st, nfe, reg_val = 0.0f0, rng, training)
-end
 
-function __biased_regularized_neural_ode(n::RegularizedNeuralODE, x, p, st)
-    isempty(n.args) && throw(
-        ArgumentError(
-            "Local regularization for `NeuralODE` requires an explicit solver algorithm, " *
-            "for example `Tsit5()`."
-        ),
-    )
+    sol, model_st, prob = solve_node(n, x, p, st, solve_kwargs)
+    treg, ureg = CRC.@ignore_derivatives (reservoir.treg, reservoir.ureg)
+    (treg === nothing || ureg === nothing) &&
+        error("Biased regularization requires at least one accepted-step candidate.")
 
-    solve_kwargs = let kws = n.kwargs
-        haskey(kws, :saveat) ? kws : merge(kws, (; saveat = []))
-    end
-    sol, model_st, prob = __regularized_solve(n, x, p, st; kwargs = solve_kwargs)
-    rng = Lux.replicate(hasproperty(st, :rng) ? st.rng : Random.default_rng())
-    training = hasproperty(st, :training) ? st.training : Val(true)
-    idx = CRC.@ignore_derivatives begin
-        isempty(sol.t) && error("Biased regularization requires at least one saved solution state.")
-        length(sol.t) == 1 ? firstindex(sol.t) :
-        rand(rng, firstindex(sol.t):(lastindex(sol.t) - 1))
-    end
-    treg = sol.t[idx]
-    ureg = sol.u[idx]
     integrator = CRC.@ignore_derivatives begin
         local_prob = remake(prob; u0 = ureg, tspan = (treg, last(prob.tspan)))
-        SciMLBase.init(local_prob, n.args...; solve_kwargs...)
+        SciMLBase.init(local_prob, n.args...; kws...)
     end
-    reg_val, local_nf = local_regularization_step(integrator, integrator.cache, p)
-    nfe = max(__ode_nfe(sol), 0) + local_nf
+    reg_val, local_nf = local_regularization_step(integrator, p)
+    nfe = sol.destats.nf + local_nf
 
-    return sol, (; model = model_st, nfe, reg_val, rng, training)
+    sol, (; model = model_st, nfe, reg_val, rng, st.training)
 end
 
-function __unbiased_regularized_neural_ode(n::RegularizedNeuralODE, x, p, st)
-    isempty(n.args) && throw(
-        ArgumentError(
-            "Local regularization for `NeuralODE` requires an explicit solver algorithm, " *
-            "for example `Tsit5()`."
-        ),
-    )
-
-    rng = Lux.replicate(hasproperty(st, :rng) ? st.rng : Random.default_rng())
-    training = hasproperty(st, :training) ? st.training : Val(true)
+function unbiased_node(n::RegularizedNeuralODE, x, p, st)
+    rng = Lux.replicate(st.rng)
     t0, t1 = n.tspan
     treg = CRC.@ignore_derivatives rand(rng, typeof(t1 - t0)) * (t1 - t0) + t0
     solve_kwargs, needs_correction = CRC.@ignore_derivatives begin
-        kws = n.kwargs
-        if haskey(kws, :saveat)
-            saveat = collect(kws[:saveat])
-            needs_correction = findfirst(isequal(treg), saveat) === nothing
-            needs_correction && push!(saveat, treg)
+        if haskey(n.kwargs, :saveat)
+            saveat = n.kwargs[:saveat] isa Number ? [n.kwargs[:saveat]] : collect(n.kwargs[:saveat])
+            idx = findfirst(isequal(treg), saveat)
+            idx === nothing && push!(saveat, treg)
             sort!(saveat)
-            merge(kws, (; saveat)), needs_correction
+            merge(n.kwargs, (; saveat)), idx === nothing
         else
-            saveat = sort!([treg, last(n.tspan)])
-            merge(kws, (; saveat)), false
+            merge(n.kwargs, (; saveat = sort!([treg, last(n.tspan)]))), false
         end
     end
-    sol, model_st, prob = __regularized_solve(n, x, p, st; kwargs = solve_kwargs)
-    t_idx = CRC.@ignore_derivatives begin
+    sol, model_st, prob = solve_node(n, x, p, st, solve_kwargs)
+    idx = CRC.@ignore_derivatives begin
         idx = findfirst(isequal(treg), sol.t)
         idx === nothing &&
-            error("Failed to recover unbiased regularization point from saved solution grid.")
+            error("Failed to recover unbiased regularization state from the saved solution grid.")
         idx
     end
-    ureg = sol.u[t_idx]
+    ureg = sol.u[idx]
+    needs_correction && (
+        sol = CRC.@ignore_derivatives SciMLBase.solution_slice(
+            sol, filter(i -> i != idx, eachindex(sol.t))
+        )
+    )
     integrator = CRC.@ignore_derivatives begin
         local_prob = remake(prob; u0 = ureg, tspan = (treg, last(prob.tspan)))
-        SciMLBase.init(local_prob, n.args...; solve_kwargs...)
+        SciMLBase.init(local_prob, n.args...; n.kwargs...)
     end
-    reg_val, local_nf = local_regularization_step(integrator, integrator.cache, p)
-    nfe = max(__ode_nfe(sol), 0) + local_nf
-    sol_out = if needs_correction
-        keep = CRC.@ignore_derivatives filter(i -> i != t_idx, eachindex(sol.t))
-        CRC.@ignore_derivatives SciMLBase.solution_slice(sol, keep)
-    else
-        sol
-    end
+    reg_val, local_nf = local_regularization_step(integrator, p)
+    nfe = sol.destats.nf + local_nf
 
-    return sol_out, (; model = model_st, nfe, reg_val, rng, training)
+    sol, (; model = model_st, nfe, reg_val, rng, st.training)
 end
 
-function (n::RegularizedNeuralODE)(x, p, st)
-    training = hasproperty(st, :training) ? st.training : Val(true)
-    return n(x, p, st, training)
-end
+(n::RegularizedNeuralODE)(x, p, st) = n(x, p, st, st.training)
 
-(n::RegularizedNeuralODE)(x, p, st, ::Val{false}) = __vanilla_regularized_neural_ode(n, x, p, st)
+(n::RegularizedNeuralODE)(x, p, st, ::Val{false}) = vanilla_node(
+    n, x, p, st
+)
 
-function (n::RegularizedNeuralODE)(x, p, st, ::Val{true})
-    return if n.regularize === :none
-        __vanilla_regularized_neural_ode(n, x, p, st)
-    elseif n.regularize === :unbiased
-        __unbiased_regularized_neural_ode(n, x, p, st)
-    else
-        __biased_regularized_neural_ode(n, x, p, st)
-    end
-end
+(n::RegularizedNeuralODE{:none})(x, p, st, ::Val) = vanilla_node(
+    n, x, p, st
+)
+
+(n::RegularizedNeuralODE{:unbiased})(x, p, st, ::Val{true}) = unbiased_node(
+    n, x, p, st
+)
+
+(n::RegularizedNeuralODE{:biased})(x, p, st, ::Val{true}) = biased_node(
+    n, x, p, st
+)
+

--- a/src/neural_de_regularization.jl
+++ b/src/neural_de_regularization.jl
@@ -1,0 +1,235 @@
+struct ArrayAndTime{A, T <: Real}
+    array::A
+    scalar::T
+end
+
+function Lux.apply(l::AbstractLuxLayer, x::ArrayAndTime, ps, st::NamedTuple)
+    y, st_ = Lux.apply(l, x.array, ps, st)
+    return ArrayAndTime(y, x.scalar), st_
+end
+
+struct TDChain{L <: NamedTuple} <: AbstractLuxWrapperLayer{:layers}
+    layers::L
+
+    TDChain(c::Chain) = new{typeof(c.layers)}(c.layers)
+    TDChain(; kwargs...) = new{typeof((; kwargs...))}((; kwargs...))
+    TDChain(layers::NamedTuple) = new{typeof(layers)}(layers)
+end
+
+function _time_channel_like(x::AbstractArray, t, dims)
+    return fill!(similar(x, eltype(x), dims), convert(eltype(x), t))
+end
+
+CRC.@non_differentiable _time_channel_like(::Any...)
+
+function (c::TDChain)((x, t), ps, st::NamedTuple)
+    return applytdchain(c.layers, x, t, ps, st)
+end
+
+@generated function applytdchain(layers::NamedTuple{fields}, x::T, t, ps, st) where {fields, T}
+    N = length(fields)
+    cat_dim = max(ndims(T) - 1, 1)
+    x_symbols = [:x; [gensym(:x) for _ in 1:N]]
+    st_symbols = [gensym(:st) for _ in 1:N]
+    dims = Expr(:tuple, [i == cat_dim ? 1 : :(size(x, $i)) for i in 1:(ndims(T))]...)
+    block = Any[:(_t = _time_channel_like(x, t, $dims))]
+
+    for i in 1:N
+        field = fields[i]
+        push!(
+            block,
+            :(
+                ($(x_symbols[i + 1]), $(st_symbols[i])) = Lux.apply(
+                    layers.$field,
+                    cat($(x_symbols[i]), _t; dims = Val($cat_dim)),
+                    ps.$field,
+                    st.$field,
+                )
+            ),
+        )
+    end
+
+    st_out = Expr(:tuple, st_symbols...)
+    push!(block, :(return ($(x_symbols[N + 1]), _t), NamedTuple{$fields}($st_out)))
+    return Expr(:block, block...)
+end
+
+function Lux.apply(l::TDChain, x::ArrayAndTime, ps, st::NamedTuple)
+    (y, _), st_ = Lux.apply(l, (x.array, x.scalar), ps, st)
+    return ArrayAndTime(y, x.scalar), st_
+end
+
+@concrete struct RegularizedNeuralODE <: NeuralDELayer
+    model <: AbstractLuxLayer
+    tspan
+    args
+    regularize::Symbol
+    kwargs
+end
+
+    function __construct_neural_ode(model, tspan, args, regularize, kwargs)
+        regularize === nothing && return NeuralODE(model, tspan, args, kwargs)
+        if regularize isa Bool
+        regularize = regularize ? :unbiased : :none
+        end
+        regularize in (:none, :unbiased, :biased) ||
+            throw(ArgumentError("`regularize` must be one of `:none`, `:unbiased`, or `:biased`."))
+        return RegularizedNeuralODE(model, tspan, args, regularize, values(kwargs))
+    end
+
+LuxCore.initialstates(rng::AbstractRNG, n::RegularizedNeuralODE) = (;
+    model = LuxCore.initialstates(rng, n.model),
+    nfe = -1,
+    reg_val = 0.0f0,
+    rng = Lux.replicate(rng),
+    training = Val(true),
+)
+
+function __ode_nfe(sol)
+    if hasproperty(sol, :destats) && hasproperty(sol.destats, :nf)
+        return sol.destats.nf
+    elseif hasproperty(sol, :stats) && hasproperty(sol.stats, :nf)
+        return sol.stats.nf
+    else
+        return -1
+    end
+end
+
+CRC.@non_differentiable __ode_nfe(::Any...)
+
+function __regularized_solve(
+        n::RegularizedNeuralODE, x, p, st; kwargs = n.kwargs
+    )
+    model_state = hasproperty(st, :model) ? st.model : st
+    model = StatefulLuxLayer{fixed_state_type(n.model)}(
+        n.model, nothing, model_state
+    )
+
+    dudt(u, p, t) = model(ArrayAndTime(u, t), p).array
+    ff = ODEFunction{false}(dudt; tgrad = basic_tgrad)
+    prob = ODEProblem{false}(ff, x, n.tspan, p)
+    sol = solve(
+        prob, n.args...;
+        sensealg = InterpolatingAdjoint(; autojacvec = ZygoteVJP()), kwargs...
+    )
+    return sol, model.st, prob
+end
+
+function local_regularization_step(integrator, cache, p)
+    throw(
+        ArgumentError(
+            "Local regularization is not implemented for solver $(typeof(integrator.alg)) " *
+            "with cache $(typeof(cache))."
+        ),
+    )
+end
+
+function __vanilla_regularized_neural_ode(n::RegularizedNeuralODE, x, p, st)
+    solve_kwargs = let kws = n.kwargs
+        haskey(kws, :saveat) ? kws : merge(kws, (; saveat = [last(n.tspan)]))
+    end
+    sol, model_st, _ = __regularized_solve(
+        n, x, p, st; kwargs = solve_kwargs
+    )
+    nfe = __ode_nfe(sol)
+    rng = hasproperty(st, :rng) ? st.rng : Random.default_rng()
+    training = hasproperty(st, :training) ? st.training : Val(true)
+    return sol, (; model = model_st, nfe, reg_val = 0.0f0, rng, training)
+end
+
+function __biased_regularized_neural_ode(n::RegularizedNeuralODE, x, p, st)
+    isempty(n.args) && throw(
+        ArgumentError(
+            "Local regularization for `NeuralODE` requires an explicit solver algorithm, " *
+            "for example `Tsit5()`."
+        ),
+    )
+
+    solve_kwargs = let kws = n.kwargs
+        haskey(kws, :saveat) ? kws : merge(kws, (; saveat = []))
+    end
+    sol, model_st, prob = __regularized_solve(n, x, p, st; kwargs = solve_kwargs)
+    rng = Lux.replicate(hasproperty(st, :rng) ? st.rng : Random.default_rng())
+    training = hasproperty(st, :training) ? st.training : Val(true)
+    idx = CRC.@ignore_derivatives begin
+        isempty(sol.t) && error("Biased regularization requires at least one saved solution state.")
+        length(sol.t) == 1 ? firstindex(sol.t) :
+        rand(rng, firstindex(sol.t):(lastindex(sol.t) - 1))
+    end
+    treg = sol.t[idx]
+    ureg = sol.u[idx]
+    integrator = CRC.@ignore_derivatives begin
+        local_prob = remake(prob; u0 = ureg, tspan = (treg, last(prob.tspan)))
+        SciMLBase.init(local_prob, n.args...; solve_kwargs...)
+    end
+    reg_val, local_nf = local_regularization_step(integrator, integrator.cache, p)
+    nfe = max(__ode_nfe(sol), 0) + local_nf
+
+    return sol, (; model = model_st, nfe, reg_val, rng, training)
+end
+
+function __unbiased_regularized_neural_ode(n::RegularizedNeuralODE, x, p, st)
+    isempty(n.args) && throw(
+        ArgumentError(
+            "Local regularization for `NeuralODE` requires an explicit solver algorithm, " *
+            "for example `Tsit5()`."
+        ),
+    )
+
+    rng = Lux.replicate(hasproperty(st, :rng) ? st.rng : Random.default_rng())
+    training = hasproperty(st, :training) ? st.training : Val(true)
+    t0, t1 = n.tspan
+    treg = CRC.@ignore_derivatives rand(rng, typeof(t1 - t0)) * (t1 - t0) + t0
+    solve_kwargs, needs_correction = CRC.@ignore_derivatives begin
+        kws = n.kwargs
+        if haskey(kws, :saveat)
+            saveat = collect(kws[:saveat])
+            needs_correction = findfirst(isequal(treg), saveat) === nothing
+            needs_correction && push!(saveat, treg)
+            sort!(saveat)
+            merge(kws, (; saveat)), needs_correction
+        else
+            saveat = sort!([treg, last(n.tspan)])
+            merge(kws, (; saveat)), false
+        end
+    end
+    sol, model_st, prob = __regularized_solve(n, x, p, st; kwargs = solve_kwargs)
+    t_idx = CRC.@ignore_derivatives begin
+        idx = findfirst(isequal(treg), sol.t)
+        idx === nothing &&
+            error("Failed to recover unbiased regularization point from saved solution grid.")
+        idx
+    end
+    ureg = sol.u[t_idx]
+    integrator = CRC.@ignore_derivatives begin
+        local_prob = remake(prob; u0 = ureg, tspan = (treg, last(prob.tspan)))
+        SciMLBase.init(local_prob, n.args...; solve_kwargs...)
+    end
+    reg_val, local_nf = local_regularization_step(integrator, integrator.cache, p)
+    nfe = max(__ode_nfe(sol), 0) + local_nf
+    sol_out = if needs_correction
+        keep = CRC.@ignore_derivatives filter(i -> i != t_idx, eachindex(sol.t))
+        CRC.@ignore_derivatives SciMLBase.solution_slice(sol, keep)
+    else
+        sol
+    end
+
+    return sol_out, (; model = model_st, nfe, reg_val, rng, training)
+end
+
+function (n::RegularizedNeuralODE)(x, p, st)
+    training = hasproperty(st, :training) ? st.training : Val(true)
+    return n(x, p, st, training)
+end
+
+(n::RegularizedNeuralODE)(x, p, st, ::Val{false}) = __vanilla_regularized_neural_ode(n, x, p, st)
+
+function (n::RegularizedNeuralODE)(x, p, st, ::Val{true})
+    return if n.regularize === :none
+        __vanilla_regularized_neural_ode(n, x, p, st)
+    elseif n.regularize === :unbiased
+        __unbiased_regularized_neural_ode(n, x, p, st)
+    else
+        __biased_regularized_neural_ode(n, x, p, st)
+    end
+end

--- a/src/neural_de_regularization.jl
+++ b/src/neural_de_regularization.jl
@@ -25,12 +25,13 @@ end
     cat_dim = max(ndims(T) - 1, 1)
     x_symbols = vcat([:x], [gensym("x") for _ in 1:N])
     st_symbols = [gensym("st") for _ in 1:N]
+    size_expr = Expr(
+        :tuple,
+        [i == cat_dim ? 1 : :(size(x, $i)) for i in 1:ndims(T)]...,
+    )
     calls = [
         :(
-            _t = fill!(
-                similar(x, eltype(x), ntuple(i -> i == $cat_dim ? 1 : size(x, i), ndims(x))),
-                convert(eltype(x), t),
-            )
+            _t = zero.(similar(x, eltype(x), $size_expr)) .+ convert(eltype(x), t)
         ),
     ]
 
@@ -262,15 +263,19 @@ end
 
 (n::RegularizedNeuralODE)(x, p, st) = n(x, p, st, st.training)
 
-(n::RegularizedNeuralODE)(x, p, st, ::Val{false}) = vanilla_node(
-    n, x, p, st
-)
-
 (n::RegularizedNeuralODE{:none})(x, p, st, ::Val) = vanilla_node(
     n, x, p, st
 )
 
+(n::RegularizedNeuralODE{:unbiased})(x, p, st, ::Val{false}) = vanilla_node(
+    n, x, p, st
+)
+
 (n::RegularizedNeuralODE{:unbiased})(x, p, st, ::Val{true}) = unbiased_node(
+    n, x, p, st
+)
+
+(n::RegularizedNeuralODE{:biased})(x, p, st, ::Val{false}) = vanilla_node(
     n, x, p, st
 )
 

--- a/src/neural_de_regularization.jl
+++ b/src/neural_de_regularization.jl
@@ -1,0 +1,231 @@
+@concrete struct RegularizedNeuralODE{R} <: NeuralDELayer
+    model <: AbstractLuxLayer
+    tspan
+    args
+    kwargs
+end
+
+function regularized_neuralode(model, tspan, regularize, args, kwargs)
+    regularize in (:none, :unbiased, :biased) ||
+        throw(ArgumentError(
+            "regularize must be one of (:none, :unbiased, :biased), " *
+            "or `nothing` to use the ordinary NeuralODE."
+        ))
+    return RegularizedNeuralODE{regularize}(model, tspan, args, kwargs)
+end
+
+LuxCore.initialstates(rng::AbstractRNG, n::RegularizedNeuralODE) = (;
+    model = LuxCore.initialstates(rng, n.model),
+    nfe = -1,
+    reg_val = 0.0f0,
+    rng = Lux.replicate(rng),
+    training = Val(true),
+)
+
+function solve_neuralode(n::RegularizedNeuralODE, x, p, st, kwargs)
+    model = StatefulLuxLayer{fixed_state_type(n.model)}(n.model, nothing, st.model)
+    dudt(u, p, t) = model((u, t), p)
+    function dudt!(du, u, p, t)
+        copyto!(du, dudt(u, p, t))
+        return nothing
+    end
+
+    prob = ODEProblem{true}(ODEFunction{true}(dudt!), x, n.tspan, p)
+    sol = solve(
+        prob, n.args...;
+        sensealg = InterpolatingAdjoint(; autojacvec = ZygoteVJP()), kwargs...
+    )
+    sol, model.st
+end
+
+function error_estimate_regularization end
+
+mutable struct ReservoirState{R, T, U}
+    rng::R
+    count::Int
+    pending_t::Union{Nothing, T}
+    pending_u::Union{Nothing, U}
+    treg::Union{Nothing, T}
+    ureg::Union{Nothing, U}
+end
+
+function ReservoirState(rng, t::T, u::U, save_start::Bool) where {T, U}
+    pending_t = save_start ? t : nothing
+    pending_u = save_start ? copyto!(similar(u), u) : nothing
+    return ReservoirState{typeof(rng), T, U}(rng, 0, pending_t, pending_u, nothing, nothing)
+end
+
+function (state::ReservoirState)(integrator)
+    if state.pending_t !== nothing
+        state.count += 1
+        if state.count == 1 || rand(state.rng, 1:(state.count)) == 1
+            state.treg = state.pending_t
+            pending_u = state.pending_u
+            state.ureg === nothing && (state.ureg = similar(pending_u))
+            copyto!(state.ureg, pending_u)
+        end
+    end
+
+    state.pending_t = integrator.t
+    state.pending_u === nothing && (state.pending_u = similar(integrator.u))
+    copyto!(state.pending_u, integrator.u)
+    SciMLBase.u_modified!(integrator, false)
+    return nothing
+end
+
+function SciMLSensitivity._track_callback(
+        cb::SciMLBase.DiscreteCallback{C, A}, t, u, p, sensealg
+    ) where {C, A <: ReservoirState}
+    return cb
+end
+
+function SciMLSensitivity._setup_reverse_callbacks(
+        cb::SciMLBase.DiscreteCallback{C, A},
+        affect::A, sensealg, dgdu,
+        dgdp,
+        loss_ref, terminated
+    ) where {C, A <: ReservoirState}
+    return SciMLBase.DiscreteCallback(
+        (u, t, integrator) -> false,
+        integrator -> nothing;
+        save_positions = (false, false),
+    )
+end
+
+function local_regularization_from_state(n, x, p, st, kws, treg, ureg)
+    model, integrator = CRC.@ignore_derivatives begin
+        model = StatefulLuxLayer{fixed_state_type(n.model)}(n.model, nothing, st.model)
+        dudt(u, p, t) = model((u, t), p)
+        prob = ODEProblem{false}(
+            ODEFunction{false}(dudt; tgrad = basic_tgrad), x, n.tspan, p
+        )
+        local_prob = remake(prob; u0 = ureg, tspan = (treg, last(prob.tspan)))
+        model, SciMLBase.init(local_prob, n.args...; kws...)
+    end
+    return error_estimate_regularization(integrator, model, p)
+end
+
+function CRC.rrule(
+        config::CRC.RuleConfig{>:CRC.HasReverseMode},
+        ::typeof(local_regularization_from_state),
+        n, x, p, st, kws, treg, ureg
+    )
+    model, integrator = CRC.@ignore_derivatives begin
+        model = StatefulLuxLayer{fixed_state_type(n.model)}(n.model, nothing, st.model)
+        dudt(u, p, t) = model((u, t), p)
+        prob = ODEProblem{false}(
+            ODEFunction{false}(dudt; tgrad = basic_tgrad), x, n.tspan, p
+        )
+        local_prob = remake(prob; u0 = ureg, tspan = (treg, last(prob.tspan)))
+        model, SciMLBase.init(local_prob, n.args...; kws...)
+    end
+    y, local_pullback = CRC.rrule(config, error_estimate_regularization, integrator, model, p)
+
+    function local_regularization_from_state_pullback(Delta)
+        dlocal = local_pullback(Delta)
+        dp = CRC.unthunk(dlocal[4])
+        return (
+            CRC.NoTangent(),
+            CRC.NoTangent(),
+            CRC.NoTangent(),
+            dp,
+            CRC.NoTangent(),
+            CRC.NoTangent(),
+            CRC.NoTangent(),
+            CRC.NoTangent(),
+        )
+    end
+    return y, local_regularization_from_state_pullback
+end
+
+function solve_without_regularization(n::RegularizedNeuralODE, x, p, st)
+    kws = n.kwargs
+    solve_kwargs = haskey(kws, :saveat) ?
+        kws :
+        merge(kws, (; saveat = [last(n.tspan)]))
+    sol, model_st = solve_neuralode(n, x, p, st, solve_kwargs)
+    sol, (; model = model_st, nfe = sol.destats.nf, reg_val = 0.0f0, st.rng, st.training)
+end
+
+function (n::RegularizedNeuralODE{:none})(x, p, st)
+    return solve_without_regularization(n, x, p, st)
+end
+
+function solve_biased_regularization(n::RegularizedNeuralODE, x, p, st)
+    rng = Lux.replicate(st.rng)
+    kws = n.kwargs
+    reservoir = CRC.@ignore_derivatives ReservoirState(
+        rng, first(n.tspan), x, get(kws, :save_start, true)
+    )
+    solve_kwargs = CRC.@ignore_derivatives begin
+        callback = SciMLBase.DiscreteCallback(
+            (u, t, integrator) -> integrator.iter > 0,
+            reservoir;
+            save_positions = (false, false),
+        )
+        solve_kwargs = if haskey(kws, :callback) && kws[:callback] !== nothing
+            merge(kws, (; callback = SciMLBase.CallbackSet(kws[:callback], callback)))
+        else
+            merge(kws, (; callback))
+        end
+        if !haskey(kws, :saveat) &&
+           !haskey(kws, :save_everystep) &&
+           !(haskey(kws, :dense) && kws[:dense] === true)
+            solve_kwargs = merge(solve_kwargs, (; save_everystep = false, save_end = true))
+        end
+        solve_kwargs
+    end
+    sol, model_st = solve_neuralode(n, x, p, st, solve_kwargs)
+
+    treg, ureg = CRC.@ignore_derivatives begin
+        (reservoir.treg === nothing || reservoir.ureg === nothing) &&
+            error("Biased regularization requires at least one accepted-step candidate.")
+        reservoir.treg, reservoir.ureg
+    end
+    reg_val, local_nf = local_regularization_from_state(n, x, p, st, kws, treg, ureg)
+    nfe = sol.destats.nf + local_nf
+
+    sol, (; model = model_st, nfe, reg_val, rng, st.training)
+end
+
+function solve_unbiased_regularization(n::RegularizedNeuralODE, x, p, st)
+    rng = Lux.replicate(st.rng)
+    t0, t1 = n.tspan
+    kws = n.kwargs
+    treg = CRC.@ignore_derivatives rand(rng, typeof(t1 - t0)) * (t1 - t0) + t0
+    solve_kwargs = CRC.@ignore_derivatives begin
+        saveat = if haskey(kws, :saveat) && kws[:saveat] !== nothing
+            saveat = kws[:saveat] isa Number ? [kws[:saveat]] : collect(kws[:saveat])
+            any(isequal(treg), saveat) || push!(saveat, treg)
+            saveat
+        else
+            [treg, last(n.tspan)]
+        end
+        merge(kws, (; saveat = sort!(saveat)))
+    end
+    sol, model_st = solve_neuralode(n, x, p, st, solve_kwargs)
+    idx = CRC.@ignore_derivatives findfirst(isequal(treg), sol.t)
+    idx === nothing &&
+        error("Failed to recover unbiased regularization state from the saved solution grid.")
+    ureg = CRC.@ignore_derivatives copy(sol.u[idx])
+    reg_val, local_nf = local_regularization_from_state(n, x, p, st, kws, treg, ureg)
+    nfe = sol.destats.nf + local_nf
+
+    sol, (; model = model_st, nfe, reg_val, rng, st.training)
+end
+
+function (n::RegularizedNeuralODE{:unbiased})(x, p, st)
+    if st.training === Val(true)
+        return solve_unbiased_regularization(n, x, p, st)
+    else
+        return solve_without_regularization(n, x, p, st)
+    end
+end
+
+function (n::RegularizedNeuralODE{:biased})(x, p, st)
+    if st.training === Val(true)
+        return solve_biased_regularization(n, x, p, st)
+    else
+        return solve_without_regularization(n, x, p, st)
+    end
+end


### PR DESCRIPTION
Here are the [latest changes](https://github.com/SciML/DiffEqFlux.jl/pull/1016/changes/bc9477e504689e0ef4624d0f1b98e3da0f11da05)

The modifications to SciMLBase are no longer needed now. I have implemented memory reuse to improve speed. Additionally, for the `biased` part, I used reservoir sampling to reduce memory consumption (this should be mathematically equivalent to the original implementation?)





This PR is to solve [issue#817](https://github.com/SciML/DiffEqFlux.jl/issues/817).

I have completed implementing the `perform_step` for an ODE solver — Tsit5, and I ran a 3000-step MNIST ODE experiment on the AMD Radeon RX 7900 XT following the parameter settings from the paper. The results are as follows:

| Method | Train Accuracy (%) | Test Accuracy (%) | Training Time (hr) | Prediction Time (s / batch) | Testing NFE |
| --- | ---: | ---: | ---: | ---: | ---: |
| none | 99.4317 | 97.35 | 0.1655 | 0.0734 | 362.6736 |
| unbiased | 99.2800 | 97.78 | 0.1636 | 0.0630 | 286.8240 |
| biased | 99.3783 | 97.89 | 0.2114 | 0.0664 | 281.6016 |


I placed the implementation of `perform_step` in `OrdinaryDiffEq.jl/lib/OrdinaryDiffEqTsit5/src/tsit_perform_step.jl`. I am not sure if it would be appropriate to put it directly in DiffEqFlux.

```julia
@muladd function _tsit5_reg_step(k1, uprev, f, p, t, dt, abstol, reltol)
    T = constvalue(recursive_unitless_bottom_eltype(uprev))
    T2 = constvalue(typeof(one(t)))
    @OnDemandTableauExtract Tsit5ConstantCacheActual T T2
    a = dt * a21
    k2 = f(uprev + a * k1, p, t + c1 * dt)
    k3 = f(uprev + dt * (a31 * k1 + a32 * k2), p, t + c2 * dt)
    k4 = f(uprev + dt * (a41 * k1 + a42 * k2 + a43 * k3), p, t + c3 * dt)
    k5 = f(uprev + dt * (a51 * k1 + a52 * k2 + a53 * k3 + a54 * k4), p, t + c4 * dt)
    g6 = uprev + dt * (a61 * k1 + a62 * k2 + a63 * k3 + a64 * k4 + a65 * k5)
    k6 = f(g6, p, t + dt)
    unew = uprev + dt * (a71 * k1 + a72 * k2 + a73 * k3 + a74 * k4 + a75 * k5 + a76 * k6)
    k7 = f(unew, p, t + dt)
    utilde = dt *
        (
        btilde1 * k1 + btilde2 * k2 + btilde3 * k3 + btilde4 * k4 + btilde5 * k5 +
            btilde6 * k6 + btilde7 * k7
    )
    residuals = utilde ./ (abstol .+ max.(abs.(uprev), abs.(unew)) .* reltol)
    reg_val = sqrt(sum(abs2, residuals) / length(unew)) * dt
    return unew, reg_val
end

@muladd function perform_step(integrator, cache::Tsit5ConstantCache, p)
    (; t, dt, uprev, f) = integrator
    unew, reg_val = _tsit5_reg_step(
        integrator.fsalfirst,
        uprev,
        f,
        p,
        t,
        dt,
        integrator.opts.abstol,
        integrator.opts.reltol,
    )
    return unew, reg_val, 6, dt
end

function perform_step(integrator, p)
    return perform_step(integrator, integrator.cache, p)
end
```

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
