### PR TITLE
Migrate CI to centralized SciML/.github reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,9 +10,12 @@ on:
       - master
     paths-ignore:
       - 'docs/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
 jobs:
   test:
-    runs-on: ubuntu-latest
+    name: Tests
     strategy:
       fail-fast: false
       matrix:
@@ -25,30 +28,8 @@ jobs:
         version:
           - '1'
           - 'lts'
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.version }}
-      - uses: actions/cache@v5
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        env:
-          GROUP: ${{ matrix.group }}
-      - uses: julia-actions/julia-processcoverage@v1
-        with:
-          directories: src,ext
-      - uses: codecov/codecov-action@v6
-        with:
-          files: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      group: "${{ matrix.group }}"
+      julia-version: "${{ matrix.version }}"
+    secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -10,23 +10,16 @@ on:
       - master
     paths-ignore:
       - 'docs/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
 jobs:
-  test:
+  downgrade:
     if: false # Disabled: StatsBase unsatisfiable requirements on downgrade
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    name: Downgrade
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,5 +1,4 @@
 name: format-check
-
 on:
   push:
     branches:
@@ -8,15 +7,11 @@ on:
       - 'release-'
     tags: '*'
   pull_request:
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: Runic formatting
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -1,13 +1,7 @@
 name: Spell Check
-
 on: [pull_request]
-
 jobs:
   typos-check:
     name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0 
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas

This normalizes CI to the centralized SciML/.github reusable workflows (all pinned `@v1`), matching the Sundials.jl standard set. Existing behavior and matrices are preserved exactly; only the standard checks that were missing as centralized callers are converted.

## Workflows converted
- **CI.yml** (Tests) -> `tests.yml@v1`. Preserves the exact `version` x `group` matrix (`1`/`lts` x `Layers`/`BasicNeuralDE`/`AdvancedNeuralDE`/`Newton`/`QA`), `fail-fast: false`, and coverage collection (`src,ext`). Added a `concurrency` block.
- **Downgrade.yml** -> `downgrade.yml@v1`. **Kept disabled** (`if: false`, "StatsBase unsatisfiable requirements on downgrade") exactly as before. Preserves `julia-version: 1.10`, `skip: Pkg,TOML`, `allow-reresolve: false`.
- **FormatCheck.yml** (Runic) -> `runic.yml@v1`. The repo already ran `fredrikekre/runic-action`; just centralized. **No formatting changes were needed** -- `Runic.main(["--check","--diff","."])` passes clean locally (Runic v1.7.0, Julia 1.10).
- **SpellCheck.yml** -> `spellcheck.yml@v1` (was inline `crate-ci/typos`).

## Left unchanged
- **GPU.yml** -- self-hosted CUDA test job + docs build/deploy job. This is outside the standard centralized set and the docs are intentionally built/deployed on the self-hosted GPU runner (several examples require a GPU: `mnist_conv_neural_ode`, `GPUs`, `neural_gde`, etc.). A standard `documentation.yml@v1` caller on `ubuntu-latest` was deliberately **not** added to avoid (a) a likely-failing GPU-less docs build and (b) a duplicate `deploydocs` competing with GPU.yml's deploy.
- **TagBot.yml** -- unchanged.

## dependabot.yml
- **Removed** the `crate-ci/typos` ignore block (standing policy: no per-dependency ignores).
- Preserved the existing `julia` block (`/`, `/docs`, `/test`; daily; `all-julia-packages` group) and the `github-actions` block (`/`, weekly).

## CompatHelper
- No `CompatHelper.yml` existed; nothing removed. Compat automation remains via the dependabot `julia` block.

## Typos found
`typos` reports one real typo (not fixed here, surfaced for the maintainer):
- `docs/src/examples/neural_ode_weather_forecast.md:52` -- "concievable" -> "conceivable"

The centralized SpellCheck check will flag this until fixed.

## Heads-up: branch protection
Job/check names change with this migration (e.g. the Tests job is now `test / ...` via the reusable workflow). **Required-status-checks in branch protection must be updated** to the new check names, or merges may block on stale required checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)