### PR TITLE
ci: drop removed allow-reresolve input from central downgrade caller

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -21,5 +21,4 @@ jobs:
     with:
       julia-version: "1.10"
       skip: "Pkg,TOML"
-      allow-reresolve: false
     secrets: "inherit"


### PR DESCRIPTION
## Summary

The Downgrade workflow's `with:` block passes `allow-reresolve: false` to the central reusable workflow `SciML/.github/.github/workflows/downgrade.yml@v1`. That `v1` tag was retagged and **no longer declares an `allow-reresolve` input**. Passing an undeclared input to a reusable workflow fails GitHub Actions' input validation, which **errors the Downgrade job** on the default branch.

This PR removes only the now-invalid `allow-reresolve: false` line from the caller's `with:` block. No other behavior changes.

## Change

```diff
       skip: "Pkg,TOML"
-      allow-reresolve: false
     secrets: "inherit"
```

`git show --stat` is a single-file, one-line deletion (`.github/workflows/Downgrade.yml`). Verified the resulting YAML still parses and the `v1` central `downgrade.yml` no longer lists `allow-reresolve` among its `workflow_call.inputs`.

> **Please ignore this PR until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>