### PR TITLE
Canonical CI: grouped-tests.yml + root test/test_groups.toml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,22 +14,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
 jobs:
-  test:
-    name: Tests
-    strategy:
-      fail-fast: false
-      matrix:
-        group:
-          - Layers
-          - BasicNeuralDE
-          - AdvancedNeuralDE
-          - Newton
-          - QA
-        version:
-          - '1'
-          - 'lts'
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      group: "${{ matrix.group }}"
-      julia-version: "${{ matrix.version }}"
+  tests:
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,0 +1,14 @@
+[Layers]
+versions = ["lts", "1"]
+
+[BasicNeuralDE]
+versions = ["lts", "1"]
+
+[AdvancedNeuralDE]
+versions = ["lts", "1"]
+
+[Newton]
+versions = ["lts", "1"]
+
+[QA]
+versions = ["lts", "1"]


### PR DESCRIPTION
Converts the root test workflow `.github/workflows/CI.yml` from a hand-maintained `group × version` matrix into a thin caller of the reusable `SciML/.github/.github/workflows/grouped-tests.yml@v1`, with the matrix declared once in a new root `test/test_groups.toml`.

## Change
- **`CI.yml`**: the `test` job (5-group × 2-version matrix calling `tests.yml@v1`) is replaced by a single `tests` job that `uses: SciML/.github/.github/workflows/grouped-tests.yml@v1` with `secrets: inherit`. `name: CI`, the `on:` triggers (push/PR on `master`, `paths-ignore: docs/**`), and the `concurrency:` block are preserved verbatim so the `CI` branch-protection status check name is unchanged.
- **`test/test_groups.toml`** (new): declares the five existing groups — `Layers`, `BasicNeuralDE`, `AdvancedNeuralDE`, `Newton`, `QA` — each on `["lts", "1"]`.

`test/runtests.jl` already dispatches on `GROUP` for exactly these five groups, so no `runtests.jl` change is required (Category A). No `with:` inputs are needed: the package reads the default `GROUP` env var, and the old job relied on the default `check-bounds: yes` and default `coverage` over `src,ext` — all matching the reusable workflow defaults. Linux-only, so no `os` field is set (defaults to `ubuntu-latest`).

`GPU.yml` and all other workflow files are left untouched.

## Matrix match
The old `CI.yml` matrix was `{Layers, BasicNeuralDE, AdvancedNeuralDE, Newton, QA} × {1, lts}` = 10 cells. Running

```
julia scripts/compute_affected_sublibraries.jl <repo> --root-matrix
```

against the new `test/test_groups.toml` emits exactly those 10 `(group, version)` cells (all on `ubuntu-latest`, `continue_on_error: false`): **10/10 exact match.** TOML and YAML both parse cleanly.

## QA
QA group dispatch already exists in `runtests.jl`; no local Aqua/JET run was needed and none of the strict-policy exclusions were touched.

Ignore until reviewed by @ChrisRackauckas.