### PR TITLE
Document DiffEqFlux public APIs

### DIFF
--- a/docs/src/layers/CNFLayer.md
+++ b/docs/src/layers/CNFLayer.md
@@ -3,6 +3,7 @@
 The following layers are helper functions for easily building neural differential equation architectures specialized for the task of density estimation through Continuous Normalizing Flows (CNF).
 
 ```@docs
+DiffEqFlux.CNFLayer
 FFJORD
 FFJORDDistribution
 ```

--- a/docs/src/layers/NeuralDELayers.md
+++ b/docs/src/layers/NeuralDELayers.md
@@ -7,6 +7,8 @@ just work over `solve`, but these cover common use cases and choose
 what's known to be the optimal mode of AD for the respective equation type.
 
 ```@docs
+DiffEqFlux.NeuralDELayer
+DiffEqFlux.NeuralSDELayer
 NeuralODE
 NeuralDSDE
 NeuralSDE

--- a/docs/src/utilities/Collocation.md
+++ b/docs/src/utilities/Collocation.md
@@ -16,6 +16,18 @@ accumulate through time, is not as exact as other methods.
     methods, see [JuliaSimModelOptimizer](https://help.juliahub.com/jsmo/stable/manual/collocation/).
 
 ```@docs
+DiffEqFlux.CollocationKernel
+EpanechnikovKernel
+UniformKernel
+TriangularKernel
+QuarticKernel
+TriweightKernel
+TricubeKernel
+GaussianKernel
+CosineKernel
+LogisticKernel
+SigmoidKernel
+SilvermanKernel
 collocate_data
 ```
 

--- a/src/collocation.jl
+++ b/src/collocation.jl
@@ -1,14 +1,222 @@
+"""
+    CollocationKernel
+
+Abstract interface for kernels used by [`collocate_data`](@ref) when estimating
+smoothed state and derivative values from sampled time-series data.
+
+# Interface
+
+Concrete kernels are immutable marker types with zero fields. A kernel implementation
+must provide `DiffEqFlux.calckernel(kernel, t)` for an offset `t`, returning the
+kernel weight at that offset with the same numeric type as `t` when possible.
+
+Compact-support kernels may implement
+`DiffEqFlux.calckernel(kernel, t, abs(t))`; the generic two-argument method handles
+the support check and calls the three-argument method only when `abs(t) <= 1`.
+
+# Implementations
+
+The public kernel choices are [`EpanechnikovKernel`](@ref), [`UniformKernel`](@ref),
+[`TriangularKernel`](@ref), [`QuarticKernel`](@ref), [`TriweightKernel`](@ref),
+[`TricubeKernel`](@ref), [`GaussianKernel`](@ref), [`CosineKernel`](@ref),
+[`LogisticKernel`](@ref), [`SigmoidKernel`](@ref), and [`SilvermanKernel`](@ref).
+
+# Examples
+
+```julia
+using DiffEqFlux
+
+kernel = TriangularKernel()
+du, u = collocate_data(rand(2, 10), range(0, 1; length = 10), kernel)
+```
+"""
 abstract type CollocationKernel end
+
+"""
+    EpanechnikovKernel()
+
+Epanechnikov compact-support smoothing kernel for [`collocate_data`](@ref).
+
+# Returns
+
+An immutable [`CollocationKernel`](@ref) with support on `[-1, 1]`.
+
+# Examples
+
+```julia
+du, u = collocate_data(data, tpoints, EpanechnikovKernel())
+```
+"""
 struct EpanechnikovKernel <: CollocationKernel end
+
+"""
+    UniformKernel()
+
+Uniform compact-support smoothing kernel for [`collocate_data`](@ref).
+
+# Returns
+
+An immutable [`CollocationKernel`](@ref) with constant weight on `[-1, 1]`.
+
+# Examples
+
+```julia
+du, u = collocate_data(data, tpoints, UniformKernel())
+```
+"""
 struct UniformKernel <: CollocationKernel end
+
+"""
+    TriangularKernel()
+
+Triangular compact-support smoothing kernel for [`collocate_data`](@ref).
+
+# Returns
+
+An immutable [`CollocationKernel`](@ref) with linearly decaying weight on `[-1, 1]`.
+
+# Examples
+
+```julia
+du, u = collocate_data(data, tpoints, TriangularKernel())
+```
+"""
 struct TriangularKernel <: CollocationKernel end
+
+"""
+    QuarticKernel()
+
+Quartic compact-support smoothing kernel for [`collocate_data`](@ref).
+
+# Returns
+
+An immutable [`CollocationKernel`](@ref) with support on `[-1, 1]`.
+
+# Examples
+
+```julia
+du, u = collocate_data(data, tpoints, QuarticKernel())
+```
+"""
 struct QuarticKernel <: CollocationKernel end
+
+"""
+    TriweightKernel()
+
+Triweight compact-support smoothing kernel for [`collocate_data`](@ref).
+
+# Returns
+
+An immutable [`CollocationKernel`](@ref) with support on `[-1, 1]`.
+
+# Examples
+
+```julia
+du, u = collocate_data(data, tpoints, TriweightKernel())
+```
+"""
 struct TriweightKernel <: CollocationKernel end
+
+"""
+    TricubeKernel()
+
+Tricube compact-support smoothing kernel for [`collocate_data`](@ref).
+
+# Returns
+
+An immutable [`CollocationKernel`](@ref) with support on `[-1, 1]`.
+
+# Examples
+
+```julia
+du, u = collocate_data(data, tpoints, TricubeKernel())
+```
+"""
 struct TricubeKernel <: CollocationKernel end
+
+"""
+    GaussianKernel()
+
+Gaussian smoothing kernel for [`collocate_data`](@ref).
+
+# Returns
+
+An immutable [`CollocationKernel`](@ref) with non-compact Gaussian support.
+
+# Examples
+
+```julia
+du, u = collocate_data(data, tpoints, GaussianKernel())
+```
+"""
 struct GaussianKernel <: CollocationKernel end
+
+"""
+    CosineKernel()
+
+Cosine compact-support smoothing kernel for [`collocate_data`](@ref).
+
+# Returns
+
+An immutable [`CollocationKernel`](@ref) with support on `[-1, 1]`.
+
+# Examples
+
+```julia
+du, u = collocate_data(data, tpoints, CosineKernel())
+```
+"""
 struct CosineKernel <: CollocationKernel end
+
+"""
+    LogisticKernel()
+
+Logistic smoothing kernel for [`collocate_data`](@ref).
+
+# Returns
+
+An immutable [`CollocationKernel`](@ref) with non-compact logistic support.
+
+# Examples
+
+```julia
+du, u = collocate_data(data, tpoints, LogisticKernel())
+```
+"""
 struct LogisticKernel <: CollocationKernel end
+
+"""
+    SigmoidKernel()
+
+Sigmoid smoothing kernel for [`collocate_data`](@ref).
+
+# Returns
+
+An immutable [`CollocationKernel`](@ref) with non-compact sigmoid support.
+
+# Examples
+
+```julia
+du, u = collocate_data(data, tpoints, SigmoidKernel())
+```
+"""
 struct SigmoidKernel <: CollocationKernel end
+
+"""
+    SilvermanKernel()
+
+Silverman smoothing kernel for [`collocate_data`](@ref).
+
+# Returns
+
+An immutable [`CollocationKernel`](@ref) with non-compact Silverman support.
+
+# Examples
+
+```julia
+du, u = collocate_data(data, tpoints, SilvermanKernel())
+```
+"""
 struct SilvermanKernel <: CollocationKernel end
 
 function calckernel(kernel, t::T) where {T}
@@ -48,7 +256,26 @@ end
 Computes a non-parametrically smoothed estimate of `u'` and `u` given the `data`, where each
 column is a snapshot of the timeseries at `tpoints[i]`.
 
-For kernels, the following exist:
+# Arguments
+
+  - `data`: Array of observed state values. For matrix data, each column is one
+    observation at the corresponding entry of `tpoints`.
+  - `tpoints`: Sample times for `data`.
+  - `kernel`: A [`CollocationKernel`](@ref) used for local regression smoothing.
+    Defaults to [`TriangularKernel`](@ref).
+  - `bandwidth`: Smoothing bandwidth. If `nothing`, a rule-of-thumb bandwidth is used.
+  - `tpoints_sample`: Time points where interpolation-based collocation should be sampled.
+  - `interp`: DataInterpolations.jl interpolation constructor used by the extension method.
+  - `args...`: Additional positional arguments forwarded to the interpolation constructor.
+
+# Returns
+
+  - `u′`: Estimated time derivatives at the requested points.
+  - `u`: Smoothed state estimates at the requested points.
+
+# Kernel Choices
+
+The following kernel constructors are provided:
 
   - EpanechnikovKernel
   - UniformKernel
@@ -68,6 +295,16 @@ Additionally, we can use interpolation methods from
 [DataInterpolations.jl](https://github.com/SciML/DataInterpolations.jl) to generate
 data from intermediate timesteps. In this case, pass any of the methods like
 `QuadraticInterpolation` as `interp`, and the timestamps to sample from as `tpoints_sample`.
+
+# Examples
+
+```julia
+using DiffEqFlux
+
+tpoints = range(0, 1; length = 20)
+data = reduce(hcat, ([sin(t), cos(t)] for t in tpoints))
+du, u = collocate_data(data, tpoints, EpanechnikovKernel())
+```
 """
 function collocate_data(data, tpoints, kernel = TriangularKernel(), bandwidth = nothing)
     _one = oneunit(first(data))

--- a/src/ffjord.jl
+++ b/src/ffjord.jl
@@ -1,3 +1,30 @@
+"""
+    CNFLayer
+
+Abstract interface for continuous normalizing flow layers implemented by DiffEqFlux.
+
+# Interface
+
+Concrete subtypes are Lux wrapper layers and are callable as:
+
+```julia
+(logpx, λ₁, λ₂), new_state = layer(x, ps, st)
+```
+
+where `x` is a batch of samples, `ps` are Lux parameters, and `st` is Lux state. The
+first returned value contains the log density estimate and regularization terms used
+by continuous normalizing flows.
+
+# Rules
+
+  - The wrapped Lux model must be stored in a field named `model`.
+  - The state must contain `regularize` and `monte_carlo` flags.
+  - Solver keyword arguments supplied to the constructor are forwarded to `solve`.
+
+# Implementations
+
+[`FFJORD`](@ref) is the public implementation of this interface.
+"""
 abstract type CNFLayer <: AbstractLuxWrapperLayer{:model} end
 
 """
@@ -19,7 +46,7 @@ high level this corresponds to the following steps:
 After these steps one may use the NN model and the learned θ to predict the density p\\_x
 for new values of x.
 
-Arguments:
+# Arguments
 
   - `model`: A `Flux.Chain` or `Lux.AbstractLuxLayer` neural network that defines the
     dynamics of the model.
@@ -36,7 +63,35 @@ Arguments:
     [Common Solver Arguments](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
     documentation for more details.
 
-References:
+# Fields
+
+  - `model`: Lux layer used for the CNF dynamics.
+  - `basedist`: Optional base distribution. If `nothing`, a standard normal base
+    density is used.
+  - `ad`: ADTypes.jl automatic differentiation backend for the Jacobian trace estimate.
+  - `input_dims`: Dimensions of one sample, excluding the batch dimension.
+  - `tspan`: Integration time span.
+  - `args`: Positional solver arguments, usually including the ODE algorithm.
+  - `kwargs`: Keyword solver arguments forwarded to `solve`.
+
+# Returns
+
+A [`CNFLayer`](@ref). Calling the layer as `ffjord(x, ps, st)` returns
+`((logpx, λ₁, λ₂), new_state)`.
+
+# Examples
+
+```julia
+using DiffEqFlux, Lux, Random
+
+rng = Random.default_rng()
+model = Lux.Chain(Lux.Dense(2 => 8, tanh), Lux.Dense(8 => 2))
+ffjord = FFJORD(model, (0.0f0, 1.0f0), (2,))
+ps, st = Lux.setup(rng, ffjord)
+(logpx, λ₁, λ₂), st = ffjord(rand(Float32, 2, 4), ps, st)
+```
+
+# References
 
 [1] Pontryagin, Lev Semenovich. Mathematical theory of optimal processes. CRC press, 1987.
 
@@ -214,14 +269,39 @@ function __backward_ffjord(::Type{T1}, n::FFJORD, n_samples::Int, ps, st, rng) w
 end
 
 """
-FFJORD can be used as a distribution to generate new samples by `rand` or estimate densities
-by `pdf` or `logpdf` (from `Distributions.jl`).
+    FFJORDDistribution(model, ps, st)
 
-Arguments:
+Wrap an [`FFJORD`](@ref) layer as a `Distributions.jl`
+`ContinuousMultivariateDistribution`.
 
-  - `model`: A FFJORD instance.
-  - `regularize`: Whether we use regularization (default: `false`).
-  - `monte_carlo`: Whether we use monte carlo (default: `true`).
+# Arguments
+
+  - `model`: The [`FFJORD`](@ref) layer used for density evaluation and sampling.
+  - `ps`: Lux parameters for `model`.
+  - `st`: Lux state for `model`, including `regularize` and `monte_carlo`.
+
+# Fields
+
+  - `model`: Stored FFJORD layer.
+  - `ps`: Stored Lux parameters.
+  - `st`: Stored Lux state.
+
+# Returns
+
+A distribution that supports `length`, `eltype`, `logpdf`, `pdf`, and `rand`.
+
+# Examples
+
+```julia
+using DiffEqFlux, Distributions, Lux, Random
+
+rng = Random.default_rng()
+model = Lux.Chain(Lux.Dense(2 => 8, tanh), Lux.Dense(8 => 2))
+ffjord = FFJORD(model, (0.0f0, 1.0f0), (2,))
+ps, st = Lux.setup(rng, ffjord)
+d = FFJORDDistribution(ffjord, ps, st)
+logp = logpdf(d, rand(Float32, 2))
+```
 """
 @concrete struct FFJORDDistribution <: ContinuousMultivariateDistribution
     model <: FFJORD

--- a/src/multiple_shooting.jl
+++ b/src/multiple_shooting.jl
@@ -9,7 +9,7 @@ Neural Network divides the interval into smaller intervals and solves for them s
 The default continuity term is 100, implying any losses arising from the non-continuity
 of 2 different groups will be scaled by 100.
 
-Arguments:
+# Arguments
 
   - `p`: The parameters of the Neural Network to be trained.
   - `ode_data`: Original Data to be modelled.
@@ -27,6 +27,27 @@ Arguments:
     [Local Sensitivity Analysis](https://docs.sciml.ai/SciMLSensitivity/stable/) and
     [Common Solver Arguments](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
     documentation for more details.
+
+# Returns
+
+  - `loss`: Total data-fitting and continuity-penalty loss. Returns `Inf` if any
+    group solve does not have a successful retcode.
+  - `group_predictions`: Array of predictions, one entry per shooting group.
+
+# Examples
+
+```julia
+using DiffEqFlux, OrdinaryDiffEq, SciMLBase
+
+f(u, p, t) = p .* u
+prob = ODEProblem(f, [1.0], (0.0, 1.0), [1.0])
+tsteps = range(0, 1; length = 6)
+ode_data = reduce(hcat, ([exp(t)] for t in tsteps))
+loss_function(u, û) = sum(abs2, u .- û)
+
+loss, predictions = multiple_shoot(
+    [1.0], ode_data, tsteps, prob, loss_function, Tsit5(), 3; abstol = 1e-8)
+```
 
 !!! note
 
@@ -104,7 +125,7 @@ Neural Network divides the interval into smaller intervals and solves for them s
 The default continuity term is 100, implying any losses arising from the non-continuity
 of 2 different groups will be scaled by 100.
 
-Arguments:
+# Arguments
 
   - `p`: The parameters of the Neural Network to be trained.
   - `ode_data`: Original Data to be modelled.
@@ -122,6 +143,29 @@ Arguments:
   - `kwargs`: Additional arguments splatted to the ODE solver. Refer to the
     [Local Sensitivity Analysis](https://docs.sciml.ai/SciMLSensitivity/stable/) and
     [Common Solver Arguments](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/) documentation for more details.
+
+# Returns
+
+  - `loss`: Total data-fitting and continuity-penalty loss. Returns `Inf` if any
+    ensemble group solve reports non-convergence.
+  - `group_predictions`: Array of ensemble predictions, one entry per shooting group.
+
+# Examples
+
+```julia
+using DiffEqFlux, OrdinaryDiffEq, SciMLBase
+
+f(u, p, t) = p .* u
+prob = ODEProblem(f, [1.0], (0.0, 1.0), [1.0])
+ensembleprob = EnsembleProblem(prob)
+tsteps = range(0, 1; length = 6)
+ode_data = reshape([exp(t) for t in tsteps], 1, :, 1)
+loss_function(u, û) = sum(abs2, u .- û)
+
+loss, predictions = multiple_shoot(
+    [1.0], ode_data, tsteps, ensembleprob, EnsembleSerial(),
+    loss_function, Tsit5(), 3; trajectories = 1, abstol = 1e-8)
+```
 
 !!! note
 
@@ -213,12 +257,17 @@ Get ranges that partition data of length `datasize` in groups of `groupsize` obs
 If the data isn't perfectly dividable by `groupsize`, the last group contains
 the reminding observations.
 
-Arguments:
+# Arguments
 
   - `datasize`: amount of data points to be partitioned.
   - `groupsize`: maximum amount of observations in each group.
 
-Example:
+# Returns
+
+A vector of overlapping `UnitRange{Int}` values. Adjacent ranges share one index so
+the last prediction from group `k` can be compared to the first point in group `k + 1`.
+
+# Examples
 
 ```julia-repl
 julia> group_ranges(10, 5)

--- a/src/neural_de.jl
+++ b/src/neural_de.jl
@@ -1,4 +1,65 @@
+"""
+    NeuralDELayer
+
+Abstract interface for DiffEqFlux neural differential equation layers with a single
+Lux model field.
+
+# Interface
+
+Concrete subtypes are Lux layers and are callable as:
+
+```julia
+solution, new_state = layer(x, ps, st)
+```
+
+where `x` is the initial condition or layer input, `ps` are Lux parameters, and `st`
+is Lux state. Implementations must return the SciML solution produced by `solve` and
+the updated Lux state. The wrapped model is stored in a field named `model`, matching
+the `AbstractLuxWrapperLayer{:model}` interface.
+
+# Rules
+
+  - The call must not mutate `ps`.
+  - Solver keyword arguments supplied to the constructor are forwarded to `solve`.
+  - State updates from the wrapped Lux model must be returned as the second tuple value.
+
+# Implementations
+
+[`NeuralODE`](@ref), [`NeuralCDDE`](@ref), [`NeuralDAE`](@ref), and
+[`NeuralODEMM`](@ref) implement this interface.
+"""
 abstract type NeuralDELayer <: AbstractLuxWrapperLayer{:model} end
+
+"""
+    NeuralSDELayer
+
+Abstract interface for DiffEqFlux neural stochastic differential equation layers with
+separate drift and diffusion Lux models.
+
+# Interface
+
+Concrete subtypes are Lux container layers and are callable as:
+
+```julia
+solution, new_state = layer(x, ps, st)
+```
+
+where `ps` and `st` contain `drift` and `diffusion` fields. Implementations build an
+`SDEProblem`, call `solve`, and return the solution plus updated drift and diffusion
+states.
+
+# Rules
+
+  - `drift(x, ps.drift)` must return the deterministic drift vector.
+  - `diffusion(x, ps.diffusion)` must return the noise-rate object required by the
+    concrete layer.
+  - Solver keyword arguments supplied to the constructor are forwarded to `solve`.
+
+# Implementations
+
+[`NeuralDSDE`](@ref) implements diagonal noise. [`NeuralSDE`](@ref) implements a
+general noise-rate matrix with a fixed number of Brownian processes.
+"""
 abstract type NeuralSDELayer <: AbstractLuxContainerLayer{(:drift, :diffusion)} end
 
 basic_tgrad(u, p, t) = zero(u)
@@ -13,7 +74,7 @@ via adjoints [1]. At a high level this corresponds to solving the forward
 differential equation, using a second differential equation that propagates the
 derivatives of the loss backwards in time.
 
-Arguments:
+# Arguments
 
   - `model`: A `Flux.Chain` or `Lux.AbstractLuxLayer` neural network that defines the
     ̇x.
@@ -28,7 +89,31 @@ Arguments:
     [Common Solver Arguments](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
     documentation for more details.
 
-References:
+# Fields
+
+  - `model`: Lux layer used as the ODE right-hand side.
+  - `tspan`: Integration time span.
+  - `args`: Positional solver arguments, usually including the ODE algorithm.
+  - `kwargs`: Keyword solver arguments forwarded to `solve`.
+
+# Returns
+
+A [`NeuralDELayer`](@ref). Calling the layer as `node(x, ps, st)` returns
+`(sol, new_state)`, where `sol` is the SciML ODE solution.
+
+# Examples
+
+```julia
+using DiffEqFlux, Lux, Random
+
+rng = Random.default_rng()
+model = Lux.Chain(Lux.Dense(2 => 8, tanh), Lux.Dense(8 => 2))
+node = NeuralODE(model, (0.0f0, 1.0f0); saveat = 0.1f0)
+ps, st = Lux.setup(rng, node)
+sol, st = node(Float32[1, 0], ps, st)
+```
+
+# References
 
 [1] Pontryagin, Lev Semenovich. Mathematical theory of optimal processes. CRC press, 1987.
 """
@@ -66,7 +151,7 @@ end
 
 Constructs a neural stochastic differential equation (neural SDE) with diagonal noise.
 
-Arguments:
+# Arguments
 
   - `drift`: A `Flux.Chain` or `Lux.AbstractLuxLayer` neural network that defines the
     drift function.
@@ -79,6 +164,32 @@ Arguments:
   - `kwargs`: Additional arguments splatted to the ODE solver. See the
     [Common Solver Arguments](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
     documentation for more details.
+
+# Fields
+
+  - `drift`: Lux layer used as the SDE drift function.
+  - `diffusion`: Lux layer used as the diagonal diffusion function.
+  - `tspan`: Integration time span.
+  - `args`: Positional solver arguments, usually including the SDE algorithm.
+  - `kwargs`: Keyword solver arguments forwarded to `solve`.
+
+# Returns
+
+A [`NeuralSDELayer`](@ref). Calling the layer as `nsde(x, ps, st)` returns
+`(sol, new_state)`, where `sol` is the SciML SDE solution.
+
+# Examples
+
+```julia
+using DiffEqFlux, Lux, Random
+
+rng = Random.default_rng()
+drift = Lux.Dense(2 => 2)
+diffusion = Lux.Dense(2 => 2)
+layer = NeuralDSDE(drift, diffusion, (0.0f0, 1.0f0))
+ps, st = Lux.setup(rng, layer)
+sol, st = layer(Float32[1, 0], ps, st)
+```
 """
 @concrete struct NeuralDSDE <: NeuralSDELayer
     drift <: AbstractLuxLayer
@@ -117,7 +228,7 @@ end
 
 Constructs a neural stochastic differential equation (neural SDE).
 
-Arguments:
+# Arguments
 
   - `drift`: A `Flux.Chain` or `Lux.AbstractLuxLayer` neural network that defines the
     drift function.
@@ -131,6 +242,33 @@ Arguments:
   - `kwargs`: Additional arguments splatted to the ODE solver. See the
     [Common Solver Arguments](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
     documentation for more details.
+
+# Fields
+
+  - `drift`: Lux layer used as the SDE drift function.
+  - `diffusion`: Lux layer used as the full noise-rate function.
+  - `tspan`: Integration time span.
+  - `nbrown`: Number of Brownian processes.
+  - `args`: Positional solver arguments, usually including the SDE algorithm.
+  - `kwargs`: Keyword solver arguments forwarded to `solve`.
+
+# Returns
+
+A [`NeuralSDELayer`](@ref). Calling the layer as `nsde(x, ps, st)` returns
+`(sol, new_state)`, where `sol` is the SciML SDE solution.
+
+# Examples
+
+```julia
+using DiffEqFlux, Lux, Random
+
+rng = Random.default_rng()
+drift = Lux.Dense(2 => 2)
+diffusion = Lux.Dense(2 => 4)
+layer = NeuralSDE(drift, diffusion, (0.0f0, 1.0f0), 2)
+ps, st = Lux.setup(rng, layer)
+sol, st = layer(Float32[1, 0], ps, st)
+```
 """
 @concrete struct NeuralSDE <: NeuralSDELayer
     drift <: AbstractLuxLayer
@@ -172,7 +310,7 @@ end
 
 Constructs a neural delay differential equation (neural DDE) with constant delays.
 
-Arguments:
+# Arguments
 
   - `model`: A `Flux.Chain` or `Lux.AbstractLuxLayer` neural network that defines the
     derivative function. Should take an input of size `[x; x(t - lag_1); ...; x(t - lag_n)]`
@@ -189,6 +327,33 @@ Arguments:
   - `kwargs`: Additional arguments splatted to the ODE solver. See the
     [Common Solver Arguments](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
     documentation for more details.
+
+# Fields
+
+  - `model`: Lux layer used as the delayed derivative model.
+  - `tspan`: Integration time span.
+  - `hist`: History function for times before the start of the integration.
+  - `lags`: Constant delays used by the DDE.
+  - `args`: Positional solver arguments, usually including the DDE algorithm.
+  - `kwargs`: Keyword solver arguments forwarded to `solve`.
+
+# Returns
+
+A [`NeuralDELayer`](@ref). Calling the layer as `ndde(x, ps, st)` returns
+`(sol, new_state)`, where `sol` is the SciML DDE solution.
+
+# Examples
+
+```julia
+using DiffEqFlux, Lux, Random
+
+rng = Random.default_rng()
+model = Lux.Dense(4 => 2)
+hist(u, p, t) = u
+layer = NeuralCDDE(model, (0.0f0, 1.0f0), hist, [0.1f0])
+ps, st = Lux.setup(rng, layer)
+sol, st = layer(Float32[1, 0], ps, st)
+```
 """
 @concrete struct NeuralCDDE <: NeuralDELayer
     model <: AbstractLuxLayer
@@ -226,7 +391,7 @@ end
 
 Constructs a neural differential-algebraic equation (neural DAE).
 
-Arguments:
+# Arguments
 
   - `model`: A `Flux.Chain` or `Lux.AbstractLuxLayer` neural network that defines the
     derivative function. Should take an input of size `x` and produce the residual of
@@ -241,6 +406,34 @@ Arguments:
   - `kwargs`: Additional arguments splatted to the ODE solver. See the
     [Common Solver Arguments](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
     documentation for more details.
+
+# Fields
+
+  - `model`: Lux layer used for differential-variable residuals.
+  - `constraints_model`: Function returning residuals for algebraic constraints.
+  - `tspan`: Integration time span.
+  - `args`: Positional solver arguments, usually including the DAE algorithm.
+  - `differential_vars`: Boolean mask marking differential variables.
+  - `kwargs`: Keyword solver arguments forwarded to `solve`.
+
+# Returns
+
+A [`NeuralDELayer`](@ref). Calling the layer as `ndae((u0, du0), ps, st)` returns
+`(sol, new_state)`, where `sol` is the SciML DAE solution.
+
+# Examples
+
+```julia
+using DiffEqFlux, Lux, Random
+
+rng = Random.default_rng()
+model = Lux.Dense(4 => 1)
+constraints(u, p, t) = [sum(u) - 1]
+layer = NeuralDAE(model, constraints, (0.0f0, 1.0f0);
+    differential_vars = [true, false])
+ps, st = Lux.setup(rng, layer)
+sol, st = layer((Float32[1, 0], Float32[0, 0]), ps, st)
+```
 """
 @concrete struct NeuralDAE <: NeuralDELayer
     model <: AbstractLuxLayer
@@ -297,7 +490,7 @@ Mu' = f(u,p,t)
 where `M` is semi-explicit, i.e. singular with zeros for rows corresponding to the
 constraint equations.
 
-Arguments:
+# Arguments
 
   - `model`: A `Flux.Chain` or `Lux.AbstractLuxLayer` neural network that defines the
     ̇`f(u,p,t)`
@@ -317,6 +510,35 @@ Arguments:
   - `kwargs`: Additional arguments splatted to the ODE solver. See the
     [Common Solver Arguments](https://docs.sciml.ai/DiffEqDocs/stable/basics/common_solver_opts/)
     documentation for more details.
+
+# Fields
+
+  - `model`: Lux layer used for the differential rows of `f(u, p, t)`.
+  - `constraints_model`: Function returning algebraic constraint rows.
+  - `tspan`: Integration time span.
+  - `mass_matrix`: Mass matrix passed to `ODEFunction`.
+  - `args`: Positional solver arguments, usually including the implicit ODE algorithm.
+  - `kwargs`: Keyword solver arguments forwarded to `solve`.
+
+# Returns
+
+A [`NeuralDELayer`](@ref). Calling the layer as `node(x, ps, st)` returns
+`(sol, new_state)`, where `sol` is the SciML ODE solution for the mass-matrix
+formulation.
+
+# Examples
+
+```julia
+using DiffEqFlux, Lux, Random, LinearAlgebra
+
+rng = Random.default_rng()
+model = Lux.Dense(2 => 1)
+constraints(u, p, t) = [sum(u) - 1]
+mass_matrix = Diagonal([1.0f0, 0.0f0])
+layer = NeuralODEMM(model, constraints, (0.0f0, 1.0f0), mass_matrix)
+ps, st = Lux.setup(rng, layer)
+sol, st = layer(Float32[1, 0], ps, st)
+```
 """
 @concrete struct NeuralODEMM <: NeuralDELayer
     model <: AbstractLuxLayer
@@ -358,12 +580,26 @@ end
 
 Constructs an Augmented Neural Differential Equation Layer.
 
-Arguments:
+# Arguments
 
   - `nde`: Any Neural Differential Equation Layer.
   - `adim`: The number of dimensions the initial conditions should be lifted.
 
-References:
+# Returns
+
+A `Lux.Chain` that first augments the input with `adim` zero-valued dimensions and
+then calls `nde`.
+
+# Examples
+
+```julia
+using DiffEqFlux, Lux
+
+nde = NeuralODE(Lux.Dense(3 => 3), (0.0f0, 1.0f0))
+augmented = AugmentedNDELayer(nde, 1)
+```
+
+# References
 
 [1] Dupont, Emilien, Arnaud Doucet, and Yee Whye Teh. "Augmented neural ODEs." In
 Proceedings of the 33rd International Conference on Neural Information Processing
@@ -393,6 +629,30 @@ Constructs a Dimension Mover Layer.
 We can have Lux's conventional order `(data, channel, batch)` by using it as the last layer
 of `AbstractLuxLayer` to swap the batch-index and the time-index of the Neural DE's
 output considering that each time point is a channel.
+
+# Keywords
+
+  - `from`: Source dimension. Negative values are counted from the end, so `-2`
+    refers to the second-to-last dimension.
+  - `to`: Destination dimension. Negative values are counted from the end.
+
+# Fields
+
+  - `from`: Stored source dimension.
+  - `to`: Stored destination dimension.
+
+# Returns
+
+A Lux layer. Calling `DimMover(; from, to)(x, ps, st)` returns `(moved_x, st)`.
+
+# Examples
+
+```julia
+using DiffEqFlux
+
+layer = DimMover(; from = -2, to = -1)
+y, st = layer(rand(2, 3, 4), nothing, NamedTuple())
+```
 """
 @concrete struct DimMover <: AbstractLuxLayer
     from

--- a/test/QA/qa_tests.jl
+++ b/test/QA/qa_tests.jl
@@ -21,3 +21,77 @@ run_qa(
         ),
     ),
 )
+
+@testset "DiffEqFlux-owned public API docs" begin
+    public_api = [
+        :NeuralDELayer,
+        :NeuralSDELayer,
+        :CNFLayer,
+        :NeuralODE,
+        :NeuralDSDE,
+        :NeuralSDE,
+        :NeuralCDDE,
+        :NeuralDAE,
+        :AugmentedNDELayer,
+        :NeuralODEMM,
+        :FFJORD,
+        :FFJORDDistribution,
+        :DimMover,
+        :CollocationKernel,
+        :EpanechnikovKernel,
+        :UniformKernel,
+        :TriangularKernel,
+        :QuarticKernel,
+        :TriweightKernel,
+        :TricubeKernel,
+        :GaussianKernel,
+        :CosineKernel,
+        :LogisticKernel,
+        :SigmoidKernel,
+        :SilvermanKernel,
+        :collocate_data,
+        :multiple_shoot,
+        :group_ranges,
+    ]
+
+    @testset "source docstrings" begin
+        for name in public_api
+            @test Base.Docs.doc(Base.Docs.Binding(DiffEqFlux, name)) !== nothing
+        end
+    end
+
+    docs_entries = Set{String}()
+    docs_root = normpath(joinpath(@__DIR__, "..", "..", "docs", "src"))
+    for (root, _, files) in walkdir(docs_root)
+        for file in files
+            endswith(file, ".md") || continue
+            path = joinpath(root, file)
+            in_docs_block = false
+            for line in eachline(path)
+                stripped = strip(line)
+                if stripped == "```@docs"
+                    in_docs_block = true
+                elseif stripped == "```"
+                    in_docs_block = false
+                elseif in_docs_block && !isempty(stripped)
+                    push!(docs_entries, stripped)
+                end
+            end
+        end
+    end
+
+    rendered_names = Dict(
+        :NeuralDELayer => "DiffEqFlux.NeuralDELayer",
+        :NeuralSDELayer => "DiffEqFlux.NeuralSDELayer",
+        :CNFLayer => "DiffEqFlux.CNFLayer",
+        :CollocationKernel => "DiffEqFlux.CollocationKernel",
+        :group_ranges => "DiffEqFlux.group_ranges",
+    )
+
+    @testset "rendered @docs entries" begin
+        for name in public_api
+            rendered_name = get(rendered_names, name, string(name))
+            @test rendered_name in docs_entries
+        end
+    end
+end


### PR DESCRIPTION
This draft PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Add SciMLStyle-style source docstrings for DiffEqFlux-owned public/exported API, including neural layer constructors, CNF types, collocation kernels, and multiple shooting helpers.
- Document abstract layer/kernel interfaces with usage rules and implementation contracts.
- Add missing rendered `@docs` entries for the abstract interfaces and exported collocation kernels.
- Add QA coverage that checks DiffEqFlux-owned public APIs have source docstrings and rendered docs entries.

Reexported APIs from ADTypes, Lux, Boltz, and SciMLSensitivity are not duplicated here; those remain documented at their owning packages.

## Validation

- `Runic.format_file(...; inplace=true)` on touched Julia files.
- `git diff --check` passed.
- Static rendered-doc entry audit passed for all DiffEqFlux-owned public API names.
- `timeout 3600 env GROUP=QA julia +1.10 --startup-file=no --project=. -e 'using Pkg; Pkg.test()'` passed: `QA | 71 pass`.
- Broad `Pkg.test(; test_args=["qa"])` was attempted but this repo still ran the broader suite; it hit the 1-hour timeout in CNF examples after `Neural DE | 241 pass`, `Neural ODE MM | 1 pass`, and existing broken DAE/multiple-shooting tests.
- Docs build was attempted with `timeout 3600 julia +1.10 --startup-file=no --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); include("docs/make.jl")'`; it reached Documenter template expansion and executed examples, then timed out after 1 hour while still active.

Known environment warning during QA/docs: `SciMLBaseFunctionPropertiesExt` reports `FunctionProperties.islinear` missing during extension precompile/loading, but QA still completed successfully.
