### PR TITLE
Add SciMLTesting compat to CUDA test env

### DIFF
--- a/test/CUDA/Project.toml
+++ b/test/CUDA/Project.toml
@@ -11,3 +11,6 @@ SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
+[compat]
+SciMLTesting = "2.1"


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary

- Adds the missing `SciMLTesting` compat bound to `test/CUDA/Project.toml`.
- Keeps the change limited to the CUDA test environment metadata.

## Verification

- `git diff --check`
- `julia --project=. -e 'using Pkg; parsed = Pkg.TOML.parsefile("test/CUDA/Project.toml"); @assert parsed["compat"]["SciMLTesting"] == "2.1"; println("SciMLTesting compat: ", parsed["compat"]["SciMLTesting"])'`
- `julia --project=/home/crackauc/sandbox/tmp_20260708_051717_3275/.runic-env -e 'using Runic; exit(Runic.main(ARGS))' -- --check test/CUDA/Project.toml`
- `julia --project=test/CUDA -e 'using Pkg; Pkg.Registry.add("General"); Pkg.resolve(); Pkg.status(["SciMLTesting"])'` selected `SciMLTesting v2.2.0`.

I did not run the CUDA test suite locally; this PR only changes the compat bound and the local resolver check verifies the CUDA test environment can select SciMLTesting v2.
